### PR TITLE
Core constrict now supports UILayoutSupport (Deprecated since iOS 11)

### DIFF
--- a/Constrictor.podspec
+++ b/Constrictor.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.swift_version = "4.1"
   s.static_framework = true
   s.name         = "Constrictor"
-  s.version      = "0.4.0"
+  s.version      = "0.4.1"
   s.summary      = "🐍 AutoLayout's µFramework"
 
   s.description  = "(Boe) Constrictor's AutoLayout µFramework with the goal of simplying your constraints by reducing the amount of code you have to write."

--- a/Constrictor/Constrictor.xcodeproj/xcshareddata/xcschemes/Constrictor.xcscheme
+++ b/Constrictor/Constrictor.xcodeproj/xcshareddata/xcschemes/Constrictor.xcscheme
@@ -27,7 +27,17 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "53CDE3BD20B3201E007E4AE0"
+            BuildableName = "Constrictor.framework"
+            BlueprintName = "Constrictor"
+            ReferencedContainer = "container:Constrictor.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Constrictor/Constrictor/Classes/Item.swift
+++ b/Constrictor/Constrictor/Classes/Item.swift
@@ -26,6 +26,7 @@ struct Item {
 
         if #available(iOS 11.0, *) {
             secondItem = withinSafeArea ? view?.safeAreaLayoutGuide : view
+            
         } else {
             secondItem = view
         }

--- a/Constrictor/Constrictor/Extensions/UIView+Constrictor.swift
+++ b/Constrictor/Constrictor/Extensions/UIView+Constrictor.swift
@@ -61,13 +61,13 @@ public extension UIView {
      Discardable UIView to allow function's chaining.
      */
     @discardableResult func constrict(attributes: NSLayoutAttribute ..., relation: NSLayoutRelation = .equal,
-                                      to view: UIView? = nil, withinSafeArea: Bool = true, constant: CGFloat = 0.0,
+                                      to item: UIView? = nil, withinSafeArea: Bool = true, constant: CGFloat = 0.0,
                                       multiplier: CGFloat = 1.0, priority: UILayoutPriority = .required) -> UIView {
         
         attributes.forEach {
             self.constrict($0,
                            relation: relation,
-                           to: view,
+                           to: item,
                            withinSafeArea: withinSafeArea,
                            attribute: $0,
                            constant: constant,
@@ -79,7 +79,7 @@ public extension UIView {
     }
 
     /**
-     Core method of the Constrictor's framework. Most flexible function that's able to apply any constraint.
+     Core method of the Constrictor's framework. Works also with UILayoutSupport. Most flexible function that's able to apply any constraint.
 
      - returns:
      Discardable UIView to allow function's chaining.
@@ -98,22 +98,40 @@ public extension UIView {
      Discardable UIView to allow function's chaining.
      */
     @discardableResult func constrict(_ selfAttribute: NSLayoutAttribute, relation: NSLayoutRelation = .equal,
-                                      to view: UIView? = nil, withinSafeArea: Bool = true,
+                                      to item: Any? = nil, withinSafeArea: Bool = true,
                                       attribute: NSLayoutAttribute = .notAnAttribute, constant: CGFloat = 0.0,
                                       multiplier: CGFloat = 1.0, priority: UILayoutPriority = .required) -> UIView {
 
-
         translatesAutoresizingMaskIntoConstraints = false
-
         let constant = Constant.normalizeConstant(for: selfAttribute, value: constant)
 
-        NSLayoutConstraint(item: self,
-                           attribute: selfAttribute,
-                           relatedBy: relation,
-                           toItem: Item.object(for: view, withinSafeArea: withinSafeArea),
-                           attribute: attribute,
-                           multiplier: multiplier,
-                           constant: constant).isActive = true
+        if let view = item as? UIView {
+            NSLayoutConstraint(item: self,
+                               attribute: selfAttribute,
+                               relatedBy: relation,
+                               toItem: Item.object(for: view, withinSafeArea: withinSafeArea),
+                               attribute: attribute,
+                               multiplier: multiplier,
+                               constant: constant).isActive = true
+
+        } else if let guide = item as? UILayoutSupport {
+            NSLayoutConstraint(item: self,
+                               attribute: selfAttribute,
+                               relatedBy: relation,
+                               toItem: guide,
+                               attribute: attribute,
+                               multiplier: multiplier,
+                               constant: constant).isActive = true
+
+        } else {
+            NSLayoutConstraint(item: self,
+                               attribute: selfAttribute,
+                               relatedBy: relation,
+                               toItem: nil,
+                               attribute: attribute,
+                               multiplier: multiplier,
+                               constant: constant).isActive = true
+        }
 
         return self
     }

--- a/Constrictor/ConstrictorTests/Protocols/ConstraintTestable.swift
+++ b/Constrictor/ConstrictorTests/Protocols/ConstraintTestable.swift
@@ -26,8 +26,22 @@ extension ConstraintTestable where Self: XCTestCase {
         XCTAssertEqual(constraint.relation, relation)
     }
 
-    func expectedConstraintCount(based number: Int, relatedToSafeArea: Bool = true, isInContainer: Bool = false) -> Int {
+    func expectedConstraintCount(based number: Int, relatedToSafeArea: Bool = true,
+                                 numberOfGuides: Int = 0, isInContainer: Bool = false) -> Int {
 
-        return relatedToSafeArea && isInContainer ? number + 4 : number
+        let guidesConstraints = 4
+
+        if isInContainer, relatedToSafeArea, numberOfGuides > 0 {
+             return number + guidesConstraints + (numberOfGuides * 2)
+
+        } else if isInContainer {
+            return number + guidesConstraints
+
+        } else if numberOfGuides > 0 {
+            return number * (numberOfGuides * 2)
+
+        } else {
+            return number
+        }
     }
 }

--- a/Constrictor/ConstrictorTests/Protocols/ConstraintTestable.swift
+++ b/Constrictor/ConstrictorTests/Protocols/ConstraintTestable.swift
@@ -34,11 +34,11 @@ extension ConstraintTestable where Self: XCTestCase {
         if isInContainer, relatedToSafeArea, numberOfGuides > 0 {
              return number + guidesConstraints + (numberOfGuides * 2)
 
+        } else if numberOfGuides > 0 {
+            return number + (numberOfGuides * 2)
+
         } else if isInContainer {
             return number + guidesConstraints
-
-        } else if numberOfGuides > 0 {
-            return number * (numberOfGuides * 2)
 
         } else {
             return number

--- a/Constrictor/ConstrictorTests/Tests/Extensions/UIView+ConstrictorTests.swift
+++ b/Constrictor/ConstrictorTests/Tests/Extensions/UIView+ConstrictorTests.swift
@@ -113,6 +113,42 @@ class UIViewConstrictorTests: XCTestCase, ConstraintTestable {
         testConstraint(trailingConstraint)
     }
 
+    // MARK: Test - constrict(_ selfAttribute: NSLayoutAttribute, ...
+    func testConstrictAtEdgesWithLayoutGuidesWithoutDisablingSafeArea() {
+
+        // Setup
+        viewController.view.addSubview(aView)
+        aView.constrict(.top, to: viewController.topLayoutGuide, attribute: .bottom)
+            .constrict(.bottom, to: viewController.bottomLayoutGuide, attribute: .top)
+            .constrict(.trailing, to: viewController.view, attribute: .trailing)
+            .constrict(.leading, to: viewController.view, attribute: .leading)
+
+        // Tests
+        XCTAssertEqual(viewController.view.constraints.count,
+                       expectedConstraintCount(based: 4, numberOfGuides: 2, isInContainer: true))
+
+        let topConstraints = viewController.view.findConstraints(for: .top, relatedTo: aView)
+        let bottomConstraints = viewController.view.findConstraints(for: .bottom, relatedTo: aView)
+        let leadingConstraints = viewController.view.findConstraints(for: .leading, relatedTo: aView)
+        let trailingConstraints = viewController.view.findConstraints(for: .trailing, relatedTo: aView)
+
+        XCTAssertEqual(topConstraints.count, 1)
+        XCTAssertEqual(bottomConstraints.count, 1)
+        XCTAssertEqual(leadingConstraints.count, 1)
+        XCTAssertEqual(trailingConstraints.count, 1)
+
+        guard let topConstraint = topConstraints.first,
+            let bottomConstraint = bottomConstraints.first,
+            let leadingConstraint = leadingConstraints.first,
+            let trailingConstraint = trailingConstraints.first
+            else { return XCTFail() }
+
+        testConstraint(topConstraint)
+        testConstraint(bottomConstraint)
+        testConstraint(leadingConstraint)
+        testConstraint(trailingConstraint)
+    }
+
     func testConstrictEdgesWithConstants() {
 
         // Setup

--- a/Constrictor/ConstrictorTests/Tests/Extensions/UIView+ConstrictorTests.swift
+++ b/Constrictor/ConstrictorTests/Tests/Extensions/UIView+ConstrictorTests.swift
@@ -77,6 +77,42 @@ class UIViewConstrictorTests: XCTestCase, ConstraintTestable {
         testConstraint(trailingConstraint)
     }
 
+    // MARK: Test - constrict(_ selfAttribute: NSLayoutAttribute, ...
+    func testConstrictAtEdgesWithLayoutGuides() {
+
+        // Setup
+        viewController.view.addSubview(aView)
+        aView.constrict(.top, to: viewController.topLayoutGuide, withinSafeArea: false, attribute: .bottom)
+            .constrict(.bottom, to: viewController.bottomLayoutGuide, withinSafeArea: false,  attribute: .top)
+            .constrict(.trailing, to: viewController.view, withinSafeArea: false,attribute: .trailing)
+            .constrict(.leading, to: viewController.view,withinSafeArea: false,  attribute: .leading)
+
+        // Tests
+        XCTAssertEqual(viewController.view.constraints.count,
+                       expectedConstraintCount(based: 4, relatedToSafeArea: false, numberOfGuides: 2, isInContainer: true))
+
+        let topConstraints = viewController.view.findConstraints(for: .top, relatedTo: aView)
+        let bottomConstraints = viewController.view.findConstraints(for: .bottom, relatedTo: aView)
+        let leadingConstraints = viewController.view.findConstraints(for: .leading, relatedTo: aView)
+        let trailingConstraints = viewController.view.findConstraints(for: .trailing, relatedTo: aView)
+
+        XCTAssertEqual(topConstraints.count, 1)
+        XCTAssertEqual(bottomConstraints.count, 1)
+        XCTAssertEqual(leadingConstraints.count, 1)
+        XCTAssertEqual(trailingConstraints.count, 1)
+
+        guard let topConstraint = topConstraints.first,
+            let bottomConstraint = bottomConstraints.first,
+            let leadingConstraint = leadingConstraints.first,
+            let trailingConstraint = trailingConstraints.first
+            else { return XCTFail() }
+
+        testConstraint(topConstraint)
+        testConstraint(bottomConstraint)
+        testConstraint(leadingConstraint)
+        testConstraint(trailingConstraint)
+    }
+
     func testConstrictEdgesWithConstants() {
 
         // Setup


### PR DESCRIPTION
## What was done?
The core constrict method now accepts Any? instead of UIView? allowing you to pass an UILayoutSupport. In case it's not an UIView or UILayoutSupport it ignores the second item and tries to apply it to itself (like width and height)

## Why?
Provide a way to applications using versions before iOS 11 use Constrictor

## Example
When used to in a UIViewController:

```swift
let redView = UIView()
self.view.addSubview(redView)

if #available(iOS 11.0, *) {
    redView.constrictEdgesToContainer()

} else {
    redView.constrict(.top, to: self.topLayoutGuide, attribute: .bottom)
       .constrict(.bottom, to: self.bottomLayoutGuide,  attribute: .top)
       .constrict(.trailing, to: self.view, attribute: .trailing)
       .constrict(.leading, to: self.view, attribute: .leading)
}
```
