### PR TITLE
UILayoutPriority's Operators

### DIFF
--- a/Constrictor.podspec
+++ b/Constrictor.podspec
@@ -2,7 +2,7 @@ Pod::Spec.new do |s|
   s.swift_version = "4.1"
   s.static_framework = true
   s.name         = "Constrictor"
-  s.version      = "1.0.2"
+  s.version      = "1.0.3"
   s.summary      = "🐍 AutoLayout's µFramework"
 
   s.description  = "(Boe) Constrictor's AutoLayout µFramework with the goal of simplying your constraints by reducing the amount of code you have to write."

--- a/Constrictor/Constrictor.xcodeproj/project.pbxproj
+++ b/Constrictor/Constrictor.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		202473B620BA14E9005693AC /* ConstrictorAttribute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202473B520BA14E9005693AC /* ConstrictorAttribute.swift */; };
+		20572CE620F2B3AF00D21F09 /* UILayoutPriority+Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20572CE520F2B3AF00D21F09 /* UILayoutPriority+Operators.swift */; };
+		20572CE820F2B3EA00D21F09 /* UILayoutPriority+OperatorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20572CE720F2B3EA00D21F09 /* UILayoutPriority+OperatorsTests.swift */; };
 		205B527E20BADEA50016C8B8 /* UIView+Constrictable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205B527D20BADEA50016C8B8 /* UIView+Constrictable.swift */; };
 		205B528020BADEB10016C8B8 /* UIViewController+Constrictable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205B527F20BADEB10016C8B8 /* UIViewController+Constrictable.swift */; };
 		205B528720BADF330016C8B8 /* Constrictable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 205B528620BADF330016C8B8 /* Constrictable.swift */; };
@@ -42,6 +44,8 @@
 
 /* Begin PBXFileReference section */
 		202473B520BA14E9005693AC /* ConstrictorAttribute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstrictorAttribute.swift; sourceTree = "<group>"; };
+		20572CE520F2B3AF00D21F09 /* UILayoutPriority+Operators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILayoutPriority+Operators.swift"; sourceTree = "<group>"; };
+		20572CE720F2B3EA00D21F09 /* UILayoutPriority+OperatorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILayoutPriority+OperatorsTests.swift"; sourceTree = "<group>"; };
 		205B527D20BADEA50016C8B8 /* UIView+Constrictable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+Constrictable.swift"; sourceTree = "<group>"; };
 		205B527F20BADEB10016C8B8 /* UIViewController+Constrictable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+Constrictable.swift"; sourceTree = "<group>"; };
 		205B528620BADF330016C8B8 /* Constrictable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constrictable.swift; sourceTree = "<group>"; };
@@ -112,6 +116,7 @@
 				205B527D20BADEA50016C8B8 /* UIView+Constrictable.swift */,
 				205B527F20BADEB10016C8B8 /* UIViewController+Constrictable.swift */,
 				205B528820BAE5E20016C8B8 /* UILayoutGuide+Constrictable.swift */,
+				20572CE520F2B3AF00D21F09 /* UILayoutPriority+Operators.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -183,6 +188,7 @@
 				53D8199420B5818800E62D1E /* UIView+ConstrictorTests.swift */,
 				20D364DB20B6291000EF02B2 /* UIView+ConstrictorCenterTests.swift */,
 				539B841720B6C7DF00C85514 /* UIView+ConstrictorEdgesTests.swift */,
+				20572CE720F2B3EA00D21F09 /* UILayoutPriority+OperatorsTests.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -348,6 +354,7 @@
 				205B528720BADF330016C8B8 /* Constrictable.swift in Sources */,
 				20BC12FD20B98A240034207F /* UIView+ConstrictorCore.swift in Sources */,
 				53CB882320B4618B002731A6 /* Constant.swift in Sources */,
+				20572CE620F2B3AF00D21F09 /* UILayoutPriority+Operators.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -356,6 +363,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				53D819A620B5A58800E62D1E /* UIView+Finder.swift in Sources */,
+				20572CE820F2B3EA00D21F09 /* UILayoutPriority+OperatorsTests.swift in Sources */,
 				53D8199520B5818800E62D1E /* UIView+ConstrictorTests.swift in Sources */,
 				20D364DC20B6291000EF02B2 /* UIView+ConstrictorCenterTests.swift in Sources */,
 				53D819A420B5A4E700E62D1E /* ConstraintIndex.swift in Sources */,

--- a/Constrictor/Constrictor/Extensions/UILayoutPriority+Operators.swift
+++ b/Constrictor/Constrictor/Extensions/UILayoutPriority+Operators.swift
@@ -1,0 +1,19 @@
+//
+//  UILayoutPriority+Operators.swift
+//  Constrictor
+//
+//  Created by Pedro Carrasco on 08/07/2018.
+//  Copyright © 2018 Pedro Carrasco. All rights reserved.
+//
+
+import Foundation
+
+extension UILayoutPriority {
+    static func +(lhs: UILayoutPriority, rhs: Float) -> UILayoutPriority {
+        return UILayoutPriority(lhs.rawValue + rhs)
+    }
+    
+    static func -(lhs: UILayoutPriority, rhs: Float) -> UILayoutPriority {
+        return UILayoutPriority(lhs.rawValue - rhs)
+    }
+}

--- a/Constrictor/ConstrictorTests/Tests/Extensions/UILayoutPriority+OperatorsTests.swift
+++ b/Constrictor/ConstrictorTests/Tests/Extensions/UILayoutPriority+OperatorsTests.swift
@@ -1,0 +1,37 @@
+//
+//  UILayoutPriority+OperatorsTests.swift
+//  ConstrictorTests
+//
+//  Created by Pedro Carrasco on 08/07/2018.
+//  Copyright © 2018 Pedro Carrasco. All rights reserved.
+//
+
+import XCTest
+@testable import Constrictor
+
+class OperatorsTests: XCTestCase {
+    
+    // MARK: ExpectedResults
+    enum ExpectedResults {
+        
+        static let addPriority = UILayoutPriority(751.0)
+        static let substractPriority = UILayoutPriority(749.0)
+    }
+    
+    // MARK: Test - +(lhs: UILayoutPriority, rhs: Float) -> UILayoutPriority
+    func testAddPriority() {
+        let result = UILayoutPriority.defaultHigh + 1
+        
+        XCTAssertEqual(result, ExpectedResults.addPriority)
+    }
+    
+    // MARK: Test - -(lhs: UILayoutPriority, rhs: Float) -> UILayoutPriority
+    func testSubstractPriority() {
+        
+        let result = UILayoutPriority.defaultHigh - 1
+        
+        XCTAssertEqual(result, ExpectedResults.substractPriority)
+    }
+}
+
+

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ There's a sample project in this repository called [Example](https://github.com/
 - [x] CodeCoverage.io integration
 - [x] Unit Testing
 - [x] SafeAreas & LayoutGuides
+- [x] UILayoutPriority + and - operators
 - [ ] Save/return constraints so it's easier to support animations
 - [ ] More "short-syntax" methods (like edges & center)
 


### PR DESCRIPTION
## What was done?
* Added + and - operators to UILayoutPriority

## Why?
This was mainly done because in more complex scenarios sometime .defaultHigh, .defaultLow and .fittingSizeLevel might not be enough and being forced to do something like **UILayoutPriority(UILayoutPriority.defaultHigh.rawValue + 1)** ain't clean and it's a bit ugly 😢

## Code Sample
With this changes, it's now possible to create a UILayoutPriorities by adding or subtracting numbers.
Examples:
* let priorityBetweenLowAndHigh = UILayoutPriority.defaultLow + 10
* let priorityBetweenHighAndRequired = UILayoutPriority.required - 90
