### PR TITLE
Size Sugar

### DIFF
--- a/Constrictor.podspec
+++ b/Constrictor.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.swift_version = "4.2"
   s.name         = "Constrictor"
-  s.version      = "3.0.1"
+  s.version      = "4.0.0"
   s.summary      = "🐍 AutoLayout's µFramework"
 
   s.description  = "(Boe) Constrictor's AutoLayout µFramework with the goal of simplying your constraints by reducing the amount of code you have to write."

--- a/Constrictor/Constrictor.xcodeproj/project.pbxproj
+++ b/Constrictor/Constrictor.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		20D1F2BE20B35FBC00B327B7 /* Constrictable+ConstrictorEdges.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D1F2BD20B35FBC00B327B7 /* Constrictable+ConstrictorEdges.swift */; };
 		20D364DC20B6291000EF02B2 /* UIView+ConstrictorCenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D364DB20B6291000EF02B2 /* UIView+ConstrictorCenterTests.swift */; };
 		531188D8215E364D00148AF3 /* LayoutItemFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531188D7215E364D00148AF3 /* LayoutItemFactory.swift */; };
+		531188DC215E92BA00148AF3 /* Constrictable+ConstrictorSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531188DB215E92BA00148AF3 /* Constrictable+ConstrictorSize.swift */; };
+		531188DF215F942A00148AF3 /* UIView+ConstrictorSizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 531188DE215F942A00148AF3 /* UIView+ConstrictorSizeTests.swift */; };
 		537F0042213B424300BC0354 /* ConstantTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537F0041213B424300BC0354 /* ConstantTests.swift */; };
 		539B841820B6C7DF00C85514 /* UIView+ConstrictorEdgesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 539B841720B6C7DF00C85514 /* UIView+ConstrictorEdgesTests.swift */; };
 		53CB882320B4618B002731A6 /* Constant.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CB882220B4618B002731A6 /* Constant.swift */; };
@@ -57,6 +59,8 @@
 		20D1F2BD20B35FBC00B327B7 /* Constrictable+ConstrictorEdges.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Constrictable+ConstrictorEdges.swift"; sourceTree = "<group>"; };
 		20D364DB20B6291000EF02B2 /* UIView+ConstrictorCenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+ConstrictorCenterTests.swift"; sourceTree = "<group>"; };
 		531188D7215E364D00148AF3 /* LayoutItemFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LayoutItemFactory.swift; sourceTree = "<group>"; };
+		531188DB215E92BA00148AF3 /* Constrictable+ConstrictorSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Constrictable+ConstrictorSize.swift"; sourceTree = "<group>"; };
+		531188DE215F942A00148AF3 /* UIView+ConstrictorSizeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+ConstrictorSizeTests.swift"; sourceTree = "<group>"; };
 		537F0041213B424300BC0354 /* ConstantTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConstantTests.swift; sourceTree = "<group>"; };
 		539B841720B6C7DF00C85514 /* UIView+ConstrictorEdgesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+ConstrictorEdgesTests.swift"; sourceTree = "<group>"; };
 		53CB882220B4618B002731A6 /* Constant.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constant.swift; sourceTree = "<group>"; };
@@ -135,6 +139,18 @@
 				53CDE3CC20B3204D007E4AE0 /* Constrictable+Constrictor.swift */,
 				20D1F2BB20B35D4C00B327B7 /* Constrictable+ConstrictorCenter.swift */,
 				20D1F2BD20B35FBC00B327B7 /* Constrictable+ConstrictorEdges.swift */,
+				531188DB215E92BA00148AF3 /* Constrictable+ConstrictorSize.swift */,
+			);
+			path = Sugar;
+			sourceTree = "<group>";
+		};
+		531188DD215F93DD00148AF3 /* Sugar */ = {
+			isa = PBXGroup;
+			children = (
+				53D8199420B5818800E62D1E /* UIView+ConstrictorTests.swift */,
+				20D364DB20B6291000EF02B2 /* UIView+ConstrictorCenterTests.swift */,
+				539B841720B6C7DF00C85514 /* UIView+ConstrictorEdgesTests.swift */,
+				531188DE215F942A00148AF3 /* UIView+ConstrictorSizeTests.swift */,
 			);
 			path = Sugar;
 			sourceTree = "<group>";
@@ -205,6 +221,7 @@
 		53D8199220B5816C00E62D1E /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				531188DD215F93DD00148AF3 /* Sugar */,
 				53ED274720BC011800038282 /* Enumerations */,
 				53D8199920B5949900E62D1E /* Structs */,
 				53D8199320B5817400E62D1E /* Extensions */,
@@ -215,9 +232,6 @@
 		53D8199320B5817400E62D1E /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				53D8199420B5818800E62D1E /* UIView+ConstrictorTests.swift */,
-				20D364DB20B6291000EF02B2 /* UIView+ConstrictorCenterTests.swift */,
-				539B841720B6C7DF00C85514 /* UIView+ConstrictorEdgesTests.swift */,
 				20572CE720F2B3EA00D21F09 /* UILayoutPriority+OperatorsTests.swift */,
 			);
 			path = Extensions;
@@ -381,6 +395,7 @@
 				205B528920BAE5E20016C8B8 /* UILayoutGuide+Constrictable.swift in Sources */,
 				202473B620BA14E9005693AC /* ConstrictorAttribute.swift in Sources */,
 				53CDE3CD20B3204D007E4AE0 /* Constrictable+Constrictor.swift in Sources */,
+				531188DC215E92BA00148AF3 /* Constrictable+ConstrictorSize.swift in Sources */,
 				205B528020BADEB10016C8B8 /* UIViewController+Constrictable.swift in Sources */,
 				20D1F2BE20B35FBC00B327B7 /* Constrictable+ConstrictorEdges.swift in Sources */,
 				205B528720BADF330016C8B8 /* Constrictable.swift in Sources */,
@@ -400,6 +415,7 @@
 				53D8199520B5818800E62D1E /* UIView+ConstrictorTests.swift in Sources */,
 				20D364DC20B6291000EF02B2 /* UIView+ConstrictorCenterTests.swift in Sources */,
 				53D819A420B5A4E700E62D1E /* ConstraintIndex.swift in Sources */,
+				531188DF215F942A00148AF3 /* UIView+ConstrictorSizeTests.swift in Sources */,
 				53ED274920BC012C00038282 /* LayoutItemFactoryTests.swift in Sources */,
 				53D819AB20B5B1F300E62D1E /* ConstraintTestable.swift in Sources */,
 				539B841820B6C7DF00C85514 /* UIView+ConstrictorEdgesTests.swift in Sources */,

--- a/Constrictor/Constrictor/Core/Constrictable+ConstrictorCore.swift
+++ b/Constrictor/Constrictor/Core/Constrictable+ConstrictorCore.swift
@@ -15,29 +15,33 @@ extension Constrictable {
      Applies a constraint between two Constrictable items.
      
      - parameters:
-        - selfAttribute: Self's item layout attribute
-        - relation: Relation between both attributes
-        - item: Constrictable's item to apply a constraint with.
-        - attribute: Item's layout attribute to constraint with.
-        - constant: Constraint's constant
-        - multiplier: Constraint's multiplier
-        - priority: Constraint's priority
+     - selfAttribute: Self's item layout attribute
+     - relation: Relation between both attributes
+     - item: Constrictable's item to apply a constraint with.
+     - attribute: Item's layout attribute to constraint with.
+     - constant: Constraint's constant
+     - multiplier: Constraint's multiplier
+     - priority: Constraint's priority
      
      This method's responsible for abstracting and invoking methods responsible of converting ConstrictorAttribute to
      NSLayoutConstraint.Attribute and normalizing the constant based on the selfAttribute
      */
     
-    func constrict(_ selfAttribute: ConstrictorAttribute, relation: NSLayoutConstraint.Relation = .equal,
-                   to item: Constrictable, attribute: ConstrictorAttribute, constant: Constant,
-                   multiplier: CGFloat = 1.0, priority: UILayoutPriority = .required) {
+    func constrict(_ selfAttribute: ConstrictorAttribute,
+                   relation: NSLayoutConstraint.Relation = .equal,
+                   to item: Constrictable,
+                   attribute: ConstrictorAttribute,
+                   constant: Constant,
+                   multiplier: CGFloat = 1.0,
+                   priority: UILayoutPriority = .required) {
 
         prepareForAutoLayout()
 
         let items = LayoutItemFactory.makeLayoutItems(firstElement: self,
-                                                                secondElement: item,
-                                                                firstAttribute: selfAttribute,
-                                                                secondAttribute: attribute,
-                                                                constant: constant)
+                                                      secondElement: item,
+                                                      firstAttribute: selfAttribute,
+                                                      secondAttribute: attribute,
+                                                      constant: constant)
 
         NSLayoutConstraint(item: self,
                            attribute: items.head.attribute,
@@ -53,24 +57,27 @@ extension Constrictable {
      Applies a constraint to itself.
      
      - parameters:
-        - selfAttribute: Self's item layout attribute
-        - relation: Relation between constraint and constant
-        - constant: Constraint's constant
-        - multiplier: Constraint's multiplier
-        - priority: Constraint's priority
+     - selfAttribute: Self's item layout attribute
+     - relation: Relation between constraint and constant
+     - constant: Constraint's constant
+     - multiplier: Constraint's multiplier
+     - priority: Constraint's priority
      
      This method's responsible for abstracting and invoking methods responsible of converting ConstrictorAttribute to
      NSLayoutConstraint.Attribute and normalizing the constant based on the selfAttribute
      */
     
-    func constrict(_ selfAttribute: ConstrictorAttribute, relation: NSLayoutConstraint.Relation = .equal,
-                   constant: Constant, multiplier: CGFloat = 1.0, priority: UILayoutPriority = .required) {
+    func constrict(_ selfAttribute: ConstrictorAttribute,
+                   relation: NSLayoutConstraint.Relation = .equal,
+                   constant: Constant,
+                   multiplier: CGFloat = 1.0,
+                   priority: UILayoutPriority = .required) {
 
         prepareForAutoLayout()
         
         let item = LayoutItemFactory.makeLayoutItem(element: self,
-                                                              attribute: selfAttribute,
-                                                              constant: constant)
+                                                    attribute: selfAttribute,
+                                                    constant: constant)
         
         NSLayoutConstraint(item: self,
                            attribute: item.attribute,
@@ -80,7 +87,10 @@ extension Constrictable {
                            multiplier: multiplier,
                            constant: item.constant).isActive = true
     }
+}
 
+// MARK; - Utils
+private extension Constrictable {
 
     func prepareForAutoLayout() {
 

--- a/Constrictor/Constrictor/Structs/Constant.swift
+++ b/Constrictor/Constrictor/Structs/Constant.swift
@@ -52,6 +52,11 @@ extension Constant {
         case .none: self = .zero
         }
     }
+
+    init(size: CGFloat) {
+
+        self = .width(size) & .height(size)
+    }
 }
 
 // MARK: - Modifiers

--- a/Constrictor/Constrictor/Sugar/Constrictable+Constrictor.swift
+++ b/Constrictor/Constrictor/Sugar/Constrictable+Constrictor.swift
@@ -10,36 +10,7 @@ import UIKit
 
 // MARK: - Constrictor
 public extension Constrictable {
-    
-    /**
-     Applies multiple constraints between self and viewController's view.
-     Use to constrain center safely to viewController's view.
-     
-     - parameters:
-     - relation: Relation between constraint and constant.
-     - item: Constrictable's item to apply a constraint with.
-     - attributes: Item's layout attributes to constraint with.
-     - constant: Constraint's constant.
-     - multiplier: Constraint's multiplier.
-     - priority: Constraint's priority.
-     
-     - returns:
-     Discardable UIView to allow function's chaining.
-     */
-    
-    @discardableResult
-    func constrictToController(_ viewController: UIViewController, as relation: NSLayoutConstraint.Relation = .equal,
-                               to attributes: ConstrictorAttribute ..., with constant: Constant = .zero,
-                               multiplyBy multiplier: CGFloat = 1.0, prioritizeAs priority: UILayoutPriority = .required) -> Self {
-        
-        attributes.forEach {
-            self.constrict($0, relation: relation, to: viewController, attribute: $0,
-                           constant: constant, multiplier: multiplier, priority: priority)
-        }
-        
-        return self
-    }
-    
+
     /**
      Applies multiple constraints between two Constrictable items.
      
@@ -56,15 +27,20 @@ public extension Constrictable {
      */
     
     @discardableResult
-    func constrict(as relation: NSLayoutConstraint.Relation = .equal, to item: Constrictable? = nil,
-                   attributes: ConstrictorAttribute ..., with constant: Constant = .zero,
-                   multiplyBy multiplier: CGFloat = 1.0, prioritizeAs priority: UILayoutPriority = .required) -> Self {
+    func constrict(as relation: NSLayoutConstraint.Relation = .equal,
+                   to item: Constrictable? = nil,
+                   attributes: ConstrictorAttribute ...,
+                   with constant: Constant = .zero,
+                   multiplyBy multiplier: CGFloat = 1.0,
+                   prioritizeAs priority: UILayoutPriority = .required) -> Self {
         
         attributes.forEach {
             if let item = item {
-                constrict($0, relation: relation, to: item, attribute: $0, constant: constant, multiplier: multiplier, priority: priority)
+                constrict($0, relation: relation, to: item, attribute: $0,
+                          constant: constant, multiplier: multiplier, priority: priority)
             } else {
-                constrict($0, relation: relation, constant: constant, multiplier: multiplier, priority: priority)
+                constrict($0, relation: relation, constant:
+                    constant, multiplier: multiplier, priority: priority)
             }
         }
         
@@ -88,20 +64,26 @@ public extension Constrictable {
      */
     
     @discardableResult
-    func constrict(_ selfAttribute: ConstrictorAttribute, as relation: NSLayoutConstraint.Relation = .equal,
-                   to item: Constrictable? = nil, attribute: ConstrictorAttribute = .none,
-                   with constant: CGFloat = 0.0, multiplyBy multiplier: CGFloat = 1.0,
+    func constrict(_ selfAttribute: ConstrictorAttribute,
+                   as relation: NSLayoutConstraint.Relation = .equal,
+                   to item: Constrictable? = nil,
+                   attribute: ConstrictorAttribute = .none,
+                   with constant: CGFloat = 0.0,
+                   multiplyBy multiplier: CGFloat = 1.0,
                    prioritizeAs priority: UILayoutPriority = .required) -> Self {
         
         
         let constant = Constant(attribute: selfAttribute, value: constant)
         
         guard let item = item else {
-            constrict(selfAttribute, relation: relation, constant: constant, multiplier: multiplier, priority: priority)
+            constrict(selfAttribute, relation: relation,
+                      constant: constant, multiplier: multiplier, priority: priority)
+
             return self
         }
         
-        constrict(selfAttribute, relation: relation, to: item, attribute: attribute, constant: constant, multiplier: multiplier, priority: priority)
+        constrict(selfAttribute, relation: relation, to: item, attribute: attribute,
+                  constant: constant, multiplier: multiplier, priority: priority)
         
         return self
     }
@@ -131,11 +113,12 @@ public extension Constrictable where Self: UIView {
                            with constant: Constant = .zero,
                            multiplyBy multiplier: CGFloat = 1.0,
                            prioritizeAs priority: UILayoutPriority = .required) -> Self {
+
+        guard let parent = self.superview else { return self }
         
         attributes.forEach {
-            if let parent = self.superview {
-                constrict($0, relation: relation, to: parent, attribute: $0, constant: constant, multiplier: multiplier, priority: priority)
-            }
+            constrict($0, relation: relation, to: parent, attribute: $0,
+                      constant: constant, multiplier: multiplier, priority: priority)
         }
         
         return self

--- a/Constrictor/Constrictor/Sugar/Constrictable+ConstrictorCenter.swift
+++ b/Constrictor/Constrictor/Sugar/Constrictable+ConstrictorCenter.swift
@@ -1,44 +1,15 @@
-////
-////  Constrictable+ConstrictorCenter.swift
-////  Constrictor
-////
-////  Created by Pedro Carrasco on 21/05/2018.
-////  Copyright © 2018 Pedro Carrasco. All rights reserved.
-////
+//
+//  Constrictable+ConstrictorCenter.swift
+//  Constrictor
+//
+//  Created by Pedro Carrasco on 21/05/2018.
+//  Copyright © 2018 Pedro Carrasco. All rights reserved.
+//
 
-import Foundation
+import UIKit
 
 // MARK: - ConstrictorCenter
 public extension Constrictable {
-    
-    /**
-     Constricts self's center to viewController's view.
-     Use to constrain center safely to viewController's view
-     
-     - parameters:
-     - relation: Relation between center
-     - constant: Constraints's constant
-     - multiplier: Constraints's multiplier
-     - priority: Constraints's priority
-     - withinGuides: Bool indicating where to constraint to safeAreas/top and bottom layout guides or not.
-     
-     - returns:
-     Discardable UIView to allow function's chaining.
-     */
-    
-    @discardableResult
-    func constrictCenterInController(_ viewController: UIViewController,
-                                     as relation: NSLayoutConstraint.Relation = .equal,
-                                     with constant: Constant = .zero,
-                                     multiplyBy multiplier: CGFloat = 1.0,
-                                     prioritizeAs priority: UILayoutPriority = .required,
-                                     withinGuides: Bool = true) -> Self {
-        
-        constrictCenter(as: relation, to: viewController, with: constant,
-                        multiplyBy: multiplier, prioritizeAs: priority, withinGuides: withinGuides)
-        
-        return self
-    }
     
     /**
      Constricts self's center to another Constrictable.
@@ -57,7 +28,7 @@ public extension Constrictable {
     
     @discardableResult
     func constrictCenter(as relation: NSLayoutConstraint.Relation = .equal,
-                         to item: Constrictable,
+                         in item: Constrictable,
                          with constant: Constant = .zero,
                          multiplyBy multiplier: CGFloat = 1.0,
                          prioritizeAs priority: UILayoutPriority = .required,
@@ -103,7 +74,7 @@ public extension Constrictable where Self: UIView {
         
         guard let superview = superview else { return self }
         
-        constrictCenter(as: relation, to: superview, with: constant,
+        constrictCenter(as: relation, in: superview, with: constant,
                         multiplyBy: multiplier, prioritizeAs: priority, withinGuides: withinGuides)
         
         return self

--- a/Constrictor/Constrictor/Sugar/Constrictable+ConstrictorEdges.swift
+++ b/Constrictor/Constrictor/Sugar/Constrictable+ConstrictorEdges.swift
@@ -1,44 +1,15 @@
-////
-////  Constrictable+ConstrictorEdges.swift
-////  Constrictor
-////
-////  Created by Pedro Carrasco on 21/05/2018.
-////  Copyright © 2018 Pedro Carrasco. All rights reserved.
-////
+//
+//  Constrictable+ConstrictorEdges.swift
+//  Constrictor
+//
+//  Created by Pedro Carrasco on 21/05/2018.
+//  Copyright © 2018 Pedro Carrasco. All rights reserved.
+//
 
 import UIKit
 
 // MARK: - ConstrictorEdges
 public extension Constrictable {
-    
-    /**
-     Constricts self's edges to viewController's view.
-     Use to constrain edges safely to viewController's view.
-     
-     - parameters:
-     - relation: Relation between edges
-     - constant: Constraints's constant
-     - multiplier: Constraints's multiplier
-     - priority: Constraints's priority
-     - withinGuides: Bool indicating where to constraint to safeAreas/top and bottom layout guides or not.
-     
-     - returns:
-     Discardable UIView to allow function's chaining.
-     */
-    
-    @discardableResult
-    func constrictEdgesToController(_ viewController: UIViewController,
-                                    as relation: NSLayoutConstraint.Relation = .equal,
-                                    with constant: Constant = .zero,
-                                    multipiedBy multiplier: CGFloat = 1.0,
-                                    prioritizeAs priority: UILayoutPriority = .required,
-                                    withinGuides: Bool = true) -> Self {
-        
-        constrictEdges(as: relation, to: viewController, with: constant,
-                       multiplyBy: multiplier, prioritizeAs: priority, withinGuides: withinGuides)
-        
-        return self
-    }
     
     /**
      Constricts self's edges to another Constrictable.

--- a/Constrictor/Constrictor/Sugar/Constrictable+ConstrictorSize.swift
+++ b/Constrictor/Constrictor/Sugar/Constrictable+ConstrictorSize.swift
@@ -1,0 +1,119 @@
+//
+//  Constrictable+ConstrictorSize.swift
+//  Constrictor
+//
+//  Created by Pedro Carrasco on 28/09/2018.
+//  Copyright © 2018 Pedro Carrasco. All rights reserved.
+//
+
+import UIKit
+
+// MARK: - ConstrictSize
+public extension Constrictable {
+
+    /**
+     Constricts self's size to another Constrictable.
+
+     - parameters:
+     - relation: Relation between center
+     - item: Constrictable's item to match dimensions.
+     - constant: Constraints' constant
+     - multiplier: Constraints' multiplier
+     - priority: Constraints' priority
+
+     - returns:
+     Discardable UIView to allow function's chaining.
+     */
+
+    @discardableResult
+    func constrictSize(as relation: NSLayoutConstraint.Relation = .equal,
+                       to item: Constrictable,
+                       with constant: Constant = .zero,
+                       multiplyBy multiplier: CGFloat = 1.0,
+                       prioritizeAs priority: UILayoutPriority = .required) -> Self {
+
+        constrict(as: relation, to: item, attributes: .width, .height,
+                  with: constant, multiplyBy: multiplier, prioritizeAs: priority)
+
+        return self
+    }
+
+
+    /**
+     Constricts self's size based in a constant. Allows you to specify different constants to height and width
+
+     - parameters:
+     - relation: Relation between center
+     - constant: Constraints' constant
+     - priority: Constraints' priority
+
+     - returns:
+     Discardable UIView to allow function's chaining.
+     */
+
+    @discardableResult
+    func constrictSize(as relation: NSLayoutConstraint.Relation = .equal,
+                       with constant: Constant,
+                       prioritizeAs priority: UILayoutPriority = .required) -> Self {
+
+
+        constrict(as: relation, attributes: .width, .height,
+                  with: constant, prioritizeAs: priority)
+
+        return self
+    }
+
+    /**
+     Constricts self's size based in a constant. Same width & height.
+
+     - parameters:
+     - relation: Relation between center
+     - constant: Constraints' constant
+     - priority: Constraints' priority
+
+     - returns:
+     Discardable UIView to allow function's chaining.
+     */
+
+    @discardableResult
+    func constrictSize(as relation: NSLayoutConstraint.Relation = .equal,
+                       with constant: CGFloat,
+                       prioritizeAs priority: UILayoutPriority = .required) -> Self {
+
+
+        constrictSize(as: relation, with: Constant(size: constant), prioritizeAs: priority)
+
+        return self
+    }
+}
+
+// MARK: - ConstrictorCenter (UIView)
+public extension Constrictable where Self: UIView {
+
+    /**
+     Constricts self's size to its superview.
+
+     - parameters:
+     - relation: Relation between center
+     - constant: Constraints' constant
+     - multiplier: Constraints' multiplier
+     - priority: Constraints' priority
+
+     - returns:
+     Discardable UIView to allow function's chaining.
+     */
+
+    @discardableResult
+    func constrictSizeToParent(as relation: NSLayoutConstraint.Relation = .equal,
+                               with constant: Constant = .zero,
+                               multiplyBy multiplier: CGFloat = 1.0,
+                               prioritizeAs priority: UILayoutPriority = .required) -> Self {
+
+        guard let superview = superview else { return self }
+
+        constrictSize(as: relation, to: superview,
+                      with: constant, multiplyBy: multiplier, prioritizeAs: priority)
+
+        return self
+    }
+}

--- a/Constrictor/ConstrictorTests/Tests/Structs/ConstantTests.swift
+++ b/Constrictor/ConstrictorTests/Tests/Structs/ConstantTests.swift
@@ -136,6 +136,15 @@ extension ConstantTests {
         XCTAssertEqual(result, expectedResult)
     }
 
+    // MARK:  init(size: CGFloat)
+    func testInitSize() {
+
+        let expectedResult = ExpectedResult.height & ExpectedResult.width
+        let result = Constant(size: Constants.value)
+
+        XCTAssertEqual(result, expectedResult)
+    }
+
     func testNone() {
 
         let expectedResult = ExpectedResult.zero

--- a/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorCenterTests.swift
+++ b/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorCenterTests.swift
@@ -44,7 +44,7 @@ extension UIViewConstrictorCenterTests {
 
         // Setup
         viewController.view.addSubview(aView)
-        aView.constrictCenterInController(viewController, with: .all(Constants.constant), multiplyBy: Constants.multiplier)
+        aView.constrictCenter(in: viewController, with: .all(Constants.constant), multiplyBy: Constants.multiplier)
 
         // Tests
         let centerXConstraints = viewController.view.findConstraints(for: .centerX, relatedTo: aView)
@@ -64,7 +64,7 @@ extension UIViewConstrictorCenterTests {
 
         // Setup
         viewController.view.addSubview(aView)
-        aView.constrictCenterInController(viewController, withinGuides: false)
+        aView.constrictCenter(in: viewController, withinGuides: false)
 
         // Tests
         let centerXConstraints = viewController.view.findConstraints(for: .centerX, relatedTo: aView)
@@ -108,7 +108,7 @@ extension UIViewConstrictorCenterTests {
         // Setup
         viewController.view.addSubview(aView)
         viewController.view.addSubview(bView)
-        bView.constrictCenter(to: aView)
+        bView.constrictCenter(in: aView)
 
         // Tests
         let centerXConstraints = viewController.view.findConstraints(for: .centerX, relatedTo: bView)

--- a/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorCenterTests.swift
+++ b/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorCenterTests.swift
@@ -40,7 +40,7 @@ class UIViewConstrictorCenterTests: XCTestCase, ConstraintTestable {
 extension UIViewConstrictorCenterTests {
 
     // MARK: constrictCenterInParent(_ relation: NSLayoutConstraint.Relation = .equal, constant: CGFloat = 0.0, ...
-    func testConstrictCenterInSuperViewWithConstantMultiplier() {
+    func testConstrictCenterInParentWithConstantMultiplier() {
 
         // Setup
         viewController.view.addSubview(aView)

--- a/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorCenterTests.swift
+++ b/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorCenterTests.swift
@@ -39,48 +39,7 @@ class UIViewConstrictorCenterTests: XCTestCase, ConstraintTestable {
 // MARK: - Tests
 extension UIViewConstrictorCenterTests {
 
-    // MARK: constrictCenterInViewController(_ viewController: UIViewController, relation: NSLayoutConstraint.Relation = .equal, ...
-    func testConstrictCenterInViewControllerWithConstantMultiplier() {
-
-        // Setup
-        viewController.view.addSubview(aView)
-        aView.constrictCenter(in: viewController, with: .all(Constants.constant), multiplyBy: Constants.multiplier)
-
-        // Tests
-        let centerXConstraints = viewController.view.findConstraints(for: .centerX, relatedTo: aView)
-        let centerYConstraints = viewController.view.findConstraints(for: .centerY, relatedTo: aView)
-
-        XCTAssertEqual(centerXConstraints.count, 1)
-        XCTAssertEqual(centerYConstraints.count, 1)
-
-        guard let centerXConstraint = centerXConstraints.first,
-            let centerYConstraint = centerYConstraints.first else { return XCTFail() }
-
-        testConstraint(centerXConstraint, constant: Constants.constant, multiplier: Constants.multiplier)
-        testConstraint(centerYConstraint, constant: Constants.constant, multiplier: Constants.multiplier)
-    }
-
-    func testConstrictCenterInViewControllerWithoutGuides() {
-
-        // Setup
-        viewController.view.addSubview(aView)
-        aView.constrictCenter(in: viewController, withinGuides: false)
-
-        // Tests
-        let centerXConstraints = viewController.view.findConstraints(for: .centerX, relatedTo: aView)
-        let centerYConstraints = viewController.view.findConstraints(for: .centerY, relatedTo: aView)
-
-        XCTAssertEqual(centerXConstraints.count, 1)
-        XCTAssertEqual(centerYConstraints.count, 1)
-
-        guard let centerXConstraint = centerXConstraints.first,
-            let centerYConstraint = centerYConstraints.first else { return XCTFail() }
-
-        testConstraint(centerXConstraint)
-        testConstraint(centerYConstraint)
-    }
-
-    // MARK: constrictCenterInSuperview(_ relation: NSLayoutConstraint.Relation = .equal, constant: CGFloat = 0.0, ...
+    // MARK: constrictCenterInParent(_ relation: NSLayoutConstraint.Relation = .equal, constant: CGFloat = 0.0, ...
     func testConstrictCenterInSuperViewWithConstantMultiplier() {
 
         // Setup
@@ -113,6 +72,46 @@ extension UIViewConstrictorCenterTests {
         // Tests
         let centerXConstraints = viewController.view.findConstraints(for: .centerX, relatedTo: bView)
         let centerYConstraints = viewController.view.findConstraints(for: .centerY, relatedTo: bView)
+
+        XCTAssertEqual(centerXConstraints.count, 1)
+        XCTAssertEqual(centerYConstraints.count, 1)
+
+        guard let centerXConstraint = centerXConstraints.first,
+            let centerYConstraint = centerYConstraints.first else { return XCTFail() }
+
+        testConstraint(centerXConstraint)
+        testConstraint(centerYConstraint)
+    }
+
+    func testConstrictCenterInViewControllerWithConstantMultiplier() {
+
+        // Setup
+        viewController.view.addSubview(aView)
+        aView.constrictCenter(in: viewController, with: .all(Constants.constant), multiplyBy: Constants.multiplier)
+
+        // Tests
+        let centerXConstraints = viewController.view.findConstraints(for: .centerX, relatedTo: aView)
+        let centerYConstraints = viewController.view.findConstraints(for: .centerY, relatedTo: aView)
+
+        XCTAssertEqual(centerXConstraints.count, 1)
+        XCTAssertEqual(centerYConstraints.count, 1)
+
+        guard let centerXConstraint = centerXConstraints.first,
+            let centerYConstraint = centerYConstraints.first else { return XCTFail() }
+
+        testConstraint(centerXConstraint, constant: Constants.constant, multiplier: Constants.multiplier)
+        testConstraint(centerYConstraint, constant: Constants.constant, multiplier: Constants.multiplier)
+    }
+
+    func testConstrictCenterInViewControllerWithoutGuides() {
+
+        // Setup
+        viewController.view.addSubview(aView)
+        aView.constrictCenter(in: viewController, withinGuides: false)
+
+        // Tests
+        let centerXConstraints = viewController.view.findConstraints(for: .centerX, relatedTo: aView)
+        let centerYConstraints = viewController.view.findConstraints(for: .centerY, relatedTo: aView)
 
         XCTAssertEqual(centerXConstraints.count, 1)
         XCTAssertEqual(centerYConstraints.count, 1)

--- a/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorEdgesTests.swift
+++ b/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorEdgesTests.swift
@@ -37,66 +37,7 @@ class UIViewConstrictorEdgesTests: XCTestCase, ConstraintTestable {
 // MARK: - Tests
 extension UIViewConstrictorEdgesTests {
 
-    // MARK: constrictEdgesToViewController(_ viewController: UIViewController, relation: NSLayoutConstraint.Relation = .equal,
-    func testConstrictEdgesToViewControllerGuided() {
-
-        // Setup
-        viewController.view.addSubview(aView)
-        aView.constrictEdges(to: viewController)
-
-        // Tests
-        let topConstraints = viewController.view.findConstraints(for: .top, relatedTo: aView)
-        let bottomConstraints = viewController.view.findConstraints(for: .bottom, relatedTo: aView)
-        let leadingConstraints = viewController.view.findConstraints(for: .leading, relatedTo: aView)
-        let trailingConstraints = viewController.view.findConstraints(for: .trailing, relatedTo: aView)
-
-        XCTAssertEqual(topConstraints.count, 1)
-        XCTAssertEqual(bottomConstraints.count, 1)
-        XCTAssertEqual(leadingConstraints.count, 1)
-        XCTAssertEqual(trailingConstraints.count, 1)
-
-        guard let topConstraint = topConstraints.first,
-            let bottomConstraint = bottomConstraints.first,
-            let leadingConstraint = leadingConstraints.first,
-            let trailingConstraint = trailingConstraints.first
-            else { return XCTFail() }
-
-        testConstraint(topConstraint)
-        testConstraint(bottomConstraint)
-        testConstraint(leadingConstraint)
-        testConstraint(trailingConstraint)
-    }
-
-    func testConstrictEdgesToViewControllerNotGuided() {
-
-        // Setup
-        viewController.view.addSubview(aView)
-        aView.constrictEdges(to: viewController, withinGuides: false)
-
-        // Tests
-        let topConstraints = viewController.view.findConstraints(for: .top, relatedTo: aView)
-        let bottomConstraints = viewController.view.findConstraints(for: .bottom, relatedTo: aView)
-        let leadingConstraints = viewController.view.findConstraints(for: .leading, relatedTo: aView)
-        let trailingConstraints = viewController.view.findConstraints(for: .trailing, relatedTo: aView)
-
-        XCTAssertEqual(topConstraints.count, 1)
-        XCTAssertEqual(bottomConstraints.count, 1)
-        XCTAssertEqual(leadingConstraints.count, 1)
-        XCTAssertEqual(trailingConstraints.count, 1)
-
-        guard let topConstraint = topConstraints.first,
-            let bottomConstraint = bottomConstraints.first,
-            let leadingConstraint = leadingConstraints.first,
-            let trailingConstraint = trailingConstraints.first
-            else { return XCTFail() }
-
-        testConstraint(topConstraint)
-        testConstraint(bottomConstraint)
-        testConstraint(leadingConstraint)
-        testConstraint(trailingConstraint)
-    }
-
-    // MARK: constrictEdgesToSuperview(_ relation: NSLayoutConstraint.Relation = .equal, constant: CGFloat = 0.0, ...
+    // MARK: constrictEdgesToParent(_ relation: NSLayoutConstraint.Relation = .equal, constant: CGFloat = 0.0, ...
     func testConstrictEdgesToSuperViewGuided() {
 
         // Setup
@@ -164,6 +105,64 @@ extension UIViewConstrictorEdgesTests {
         viewController.view.addSubview(aView)
         viewController.view.addSubview(bView)
         aView.constrictEdges(to: bView)
+
+        // Tests
+        let topConstraints = viewController.view.findConstraints(for: .top, relatedTo: aView)
+        let bottomConstraints = viewController.view.findConstraints(for: .bottom, relatedTo: aView)
+        let leadingConstraints = viewController.view.findConstraints(for: .leading, relatedTo: aView)
+        let trailingConstraints = viewController.view.findConstraints(for: .trailing, relatedTo: aView)
+
+        XCTAssertEqual(topConstraints.count, 1)
+        XCTAssertEqual(bottomConstraints.count, 1)
+        XCTAssertEqual(leadingConstraints.count, 1)
+        XCTAssertEqual(trailingConstraints.count, 1)
+
+        guard let topConstraint = topConstraints.first,
+            let bottomConstraint = bottomConstraints.first,
+            let leadingConstraint = leadingConstraints.first,
+            let trailingConstraint = trailingConstraints.first
+            else { return XCTFail() }
+
+        testConstraint(topConstraint)
+        testConstraint(bottomConstraint)
+        testConstraint(leadingConstraint)
+        testConstraint(trailingConstraint)
+    }
+
+    func testConstrictEdgesToViewControllerGuided() {
+
+        // Setup
+        viewController.view.addSubview(aView)
+        aView.constrictEdges(to: viewController)
+
+        // Tests
+        let topConstraints = viewController.view.findConstraints(for: .top, relatedTo: aView)
+        let bottomConstraints = viewController.view.findConstraints(for: .bottom, relatedTo: aView)
+        let leadingConstraints = viewController.view.findConstraints(for: .leading, relatedTo: aView)
+        let trailingConstraints = viewController.view.findConstraints(for: .trailing, relatedTo: aView)
+
+        XCTAssertEqual(topConstraints.count, 1)
+        XCTAssertEqual(bottomConstraints.count, 1)
+        XCTAssertEqual(leadingConstraints.count, 1)
+        XCTAssertEqual(trailingConstraints.count, 1)
+
+        guard let topConstraint = topConstraints.first,
+            let bottomConstraint = bottomConstraints.first,
+            let leadingConstraint = leadingConstraints.first,
+            let trailingConstraint = trailingConstraints.first
+            else { return XCTFail() }
+
+        testConstraint(topConstraint)
+        testConstraint(bottomConstraint)
+        testConstraint(leadingConstraint)
+        testConstraint(trailingConstraint)
+    }
+
+    func testConstrictEdgesToViewControllerNotGuided() {
+
+        // Setup
+        viewController.view.addSubview(aView)
+        aView.constrictEdges(to: viewController, withinGuides: false)
 
         // Tests
         let topConstraints = viewController.view.findConstraints(for: .top, relatedTo: aView)

--- a/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorEdgesTests.swift
+++ b/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorEdgesTests.swift
@@ -42,7 +42,7 @@ extension UIViewConstrictorEdgesTests {
 
         // Setup
         viewController.view.addSubview(aView)
-        aView.constrictEdgesToController(viewController)
+        aView.constrictEdges(to: viewController)
 
         // Tests
         let topConstraints = viewController.view.findConstraints(for: .top, relatedTo: aView)
@@ -71,7 +71,7 @@ extension UIViewConstrictorEdgesTests {
 
         // Setup
         viewController.view.addSubview(aView)
-        aView.constrictEdgesToController(viewController, withinGuides: false)
+        aView.constrictEdges(to: viewController, withinGuides: false)
 
         // Tests
         let topConstraints = viewController.view.findConstraints(for: .top, relatedTo: aView)

--- a/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorEdgesTests.swift
+++ b/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorEdgesTests.swift
@@ -38,7 +38,7 @@ class UIViewConstrictorEdgesTests: XCTestCase, ConstraintTestable {
 extension UIViewConstrictorEdgesTests {
 
     // MARK: constrictEdgesToParent(_ relation: NSLayoutConstraint.Relation = .equal, constant: CGFloat = 0.0, ...
-    func testConstrictEdgesToSuperViewGuided() {
+    func testConstrictEdgesToParentGuided() {
 
         // Setup
         viewController.view.addSubview(aView)
@@ -68,7 +68,7 @@ extension UIViewConstrictorEdgesTests {
         testConstraint(trailingConstraint)
     }
 
-    func testConstrictEdgesToSuperViewNotGuided() {
+    func testConstrictEdgesToParentNotGuided() {
 
         // Setup
         viewController.view.addSubview(aView)

--- a/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorSizeTests.swift
+++ b/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorSizeTests.swift
@@ -1,0 +1,127 @@
+//
+//  UIView+ConstrictorSizeTests.swift
+//  ConstrictorTests
+//
+//  Created by Pedro Carrasco on 29/09/2018.
+//  Copyright © 2018 Pedro Carrasco. All rights reserved.
+//
+
+import XCTest
+@testable import Constrictor
+
+// MARK: - UIViewConstrictorSizeTests
+class UIViewConstrictorSizeTests: XCTestCase, ConstraintTestable {
+
+    // MARK: Constants
+    enum Constants {
+
+        static let constant: CGFloat = 50.0
+        static let multiplier: CGFloat = 0.75
+    }
+
+    // MARK: Properties
+    var viewController: UIViewController!
+    var aView: UIView!
+    var bView: UIView!
+
+    // MARK: Lifecycle
+    override func setUp() {
+        super.setUp()
+
+        aView = UIView()
+        bView = UIView()
+
+        viewController = UIViewController()
+        viewController.loadViewIfNeeded()
+    }
+}
+
+// MARK: - Tests
+extension UIViewConstrictorSizeTests {
+
+    // MARK: constrictSize(as relation: NSLayoutConstraint.Relation = .equal, to item: Constrictable, with constant: Constant = .zero, ...
+    func testConstrictSizeToViewController() {
+
+        // Setup
+        viewController.view.addSubview(aView)
+        aView.constrictSize(to: viewController, multiplyBy: Constants.multiplier)
+
+        // Tests
+        let widthConstraints = viewController.view.findConstraints(for: .width, relatedTo: aView)
+        let heightConstraints = viewController.view.findConstraints(for: .height, relatedTo: aView)
+
+        XCTAssertEqual(widthConstraints.count, 1)
+        XCTAssertEqual(heightConstraints.count, 1)
+
+        guard let widthConstraint = widthConstraints.first,
+            let heightConstraint = heightConstraints.first else { return XCTFail() }
+
+        testConstraint(widthConstraint, multiplier: Constants.multiplier)
+        testConstraint(heightConstraint, multiplier: Constants.multiplier)
+    }
+
+    func testConstrictSizeToView() {
+
+        // Setup
+        viewController.view.addSubview(aView)
+        viewController.view.addSubview(bView)
+        bView.constrictSize(to: aView)
+
+        // Tests
+        let widthConstraints = viewController.view.findConstraints(for: .width, relatedTo: bView)
+        let heightConstraints = viewController.view.findConstraints(for: .height, relatedTo: bView)
+
+        XCTAssertEqual(widthConstraints.count, 1)
+        XCTAssertEqual(heightConstraints.count, 1)
+
+        guard let widthConstraint = widthConstraints.first,
+            let heightConstraint = heightConstraints.first else { return XCTFail() }
+
+        testConstraint(widthConstraint)
+        testConstraint(heightConstraint)
+    }
+
+    // MARK: constrictSize(as relation: NSLayoutConstraint.Relation = .equal, with constant: Constant, ...
+    func testConstrictSizeToConstant() {
+
+        // Setup
+        viewController.view.addSubview(aView)
+        viewController.view.addSubview(bView)
+        bView.constrictSize(with: .height(Constants.constant) & .width(Constants.constant * 2))
+
+        // Tests
+        let widthConstraints = bView.findConstraints(for: .width, at: .secondItem)
+        let heightConstraints = bView.findConstraints(for: .height, at: .secondItem)
+
+        XCTAssertEqual(widthConstraints.count, 1)
+        XCTAssertEqual(heightConstraints.count, 1)
+
+        guard let widthConstraint = widthConstraints.first,
+            let heightConstraint = heightConstraints.first else { return XCTFail() }
+
+        testConstraint(widthConstraint, constant: Constants.constant * 2)
+        testConstraint(heightConstraint, constant: Constants.constant)
+    }
+
+    // MARK: constrictSize(as relation: NSLayoutConstraint.Relation = .equal, with constant: CGFloat, ...
+    func testConstrictSizeToConstantUniform() {
+
+        // Setup
+        viewController.view.addSubview(aView)
+        viewController.view.addSubview(bView)
+        bView.constrictSize(with: Constants.constant)
+
+        // Tests
+        let widthConstraints = bView.findConstraints(for: .width, at: .secondItem)
+        let heightConstraints = bView.findConstraints(for: .height, at: .secondItem)
+
+        XCTAssertEqual(widthConstraints.count, 1)
+        XCTAssertEqual(heightConstraints.count, 1)
+
+        guard let widthConstraint = widthConstraints.first,
+            let heightConstraint = heightConstraints.first else { return XCTFail() }
+
+        testConstraint(widthConstraint, constant: Constants.constant)
+        testConstraint(heightConstraint, constant: Constants.constant)
+    }
+}

--- a/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorSizeTests.swift
+++ b/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorSizeTests.swift
@@ -124,4 +124,26 @@ extension UIViewConstrictorSizeTests {
         testConstraint(widthConstraint, constant: Constants.constant)
         testConstraint(heightConstraint, constant: Constants.constant)
     }
+
+    // MARK: constrictSizeToParent(as relation: NSLayoutConstraint.Relation = .equal, with constant: Constant = .zero, ...
+    func testConstrictSizeToParent() {
+
+        // Setup
+        viewController.view.addSubview(aView)
+        aView.addSubview(bView)
+        bView.constrictSizeToParent(with: .all(Constants.constant), multiplyBy: Constants.multiplier)
+
+        // Tests
+        let widthConstraints = aView.findConstraints(for: .width, relatedTo: bView)
+        let heightConstraints = aView.findConstraints(for: .height, relatedTo: bView)
+
+        XCTAssertEqual(widthConstraints.count, 1)
+        XCTAssertEqual(heightConstraints.count, 1)
+
+        guard let widthConstraint = widthConstraints.first,
+            let heightConstraint = heightConstraints.first else { return XCTFail() }
+
+        testConstraint(widthConstraint, constant: Constants.constant, multiplier: Constants.multiplier)
+        testConstraint(heightConstraint, constant: Constants.constant, multiplier: Constants.multiplier)
+    }
 }

--- a/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorTests.swift
+++ b/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorTests.swift
@@ -237,7 +237,7 @@ extension UIViewConstrictorTests {
 
         // Setup
         viewController.view.addSubview(aView)
-        aView.constrictToController(viewController, to: .top, .bottom, with: .all(Constants.constant))
+        aView.constrict(to: viewController, attributes: .top, .bottom, with: .all(Constants.constant))
 
         // Tests
         XCTAssertEqual(viewController.view.constraints.count, 2)
@@ -259,7 +259,7 @@ extension UIViewConstrictorTests {
 
         // Setup
         viewController.view.addSubview(aView)
-        aView.constrictToController(viewController, to: .topGuide, .leadingGuide, multiplyBy: Constants.multiplier)
+        aView.constrict(to: viewController, attributes: .topGuide, .leadingGuide, multiplyBy: Constants.multiplier)
 
         // Tests
         let topConstraints = viewController.view.findConstraints(for: .top, relatedTo: aView)

--- a/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorTests.swift
+++ b/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorTests.swift
@@ -187,7 +187,6 @@ extension UIViewConstrictorTests {
             .constrict(.trailing, relation: .greaterThanOrEqual, to: aView, attribute: .leading, constant: .trailing(Constants.constant))
 
         // Test aView
-
         let centerXConstraints = viewController.view.findConstraints(for: .centerX, relatedTo: aView)
         let centerYConstraints = viewController.view.findConstraints(for: .centerY, relatedTo: aView)
         let widthConstraints = aView.findConstraints(for: .width, at: .secondItem)
@@ -232,7 +231,6 @@ extension UIViewConstrictorTests {
         testConstraint(bTrailingConstraint, constant: -Constants.constant, relation: .greaterThanOrEqual)
     }
 
-    // MARK:  constrictToViewController(_ viewController: UIViewController, relation: NSLayoutConstraint.Relation = .equal, attributes: ConstrictorAttribute ..., ...
     func testConstrictToViewControllerAtTopBottomConstant() {
 
         // Setup
@@ -276,8 +274,8 @@ extension UIViewConstrictorTests {
         testConstraint(leadingConstraint, multiplier: Constants.multiplier)
     }
 
-    // MARK: constrictToSuperView(_ relation: NSLayoutConstraint.Relation = .equal, attributes: ConstrictorAttribute ..., ...
-    func testConstrictToSuperviewAtTopBottomConstant() {
+    // MARK: constrictToParent(_ relation: NSLayoutConstraint.Relation = .equal, attributes: ConstrictorAttribute ..., ...
+    func testConstrictToParentAtTopBottomConstant() {
 
         // Setup
         viewController.view.addSubview(aView)
@@ -298,7 +296,7 @@ extension UIViewConstrictorTests {
         testConstraint(bottomConstraint, constant: -Constants.constant)
     }
 
-    func testConstrictToViewSuperviewAtTopBottomGuidesMultiplier() {
+    func testConstrictToParentAtTopBottomGuidesMultiplier() {
 
         // Setup
         viewController.view.addSubview(aView)

--- a/DOCUMENTATION.md
+++ b/DOCUMENTATION.md
@@ -1,56 +1,69 @@
 # Documentation 🐍
 
-- [Core](#core)
-  * [Constraint between equal attributes](#constraint-between-equal-attributes)
-    + [Multiple Attributes](#multiple-attributes)
-    + [Set Constant for all attributes](#set-constant-for-all-attributes)
-    + [Set Constant for a specific attribute](#set-constant-for-a-specific-attribute)
-    + [Set Relation](#set-relation)
-    + [Set Multiplier](#set-multiplier)
-    + [Set Priority](#set-priority)
-    + [All Above](#all-above)
-  * [Constraint between different attributes](#constraint-between-different-attributes)
-    + [Set Constant](#set-constant)
-    + [Set Relation](#set-relation-1)
-    + [Set Multiplier](#set-multiplier-1)
-    + [Set Priority](#set-priority-1)
-    + [All Above](#all-above-1)
-  * [Constraint to `superview`](#constraint-to--superview-)
-- [Edges](#edges)
-  * [Constraint edges between 2 elements](#constraint-edges-between-2-elements)
-    + [Set Constant to One Edge](#set-constant-to-one-edge)
-    + [Set Constant to Two or More Edges](#set-constant-to-two-or-more-edges)
-    + [Set Constant to All Edges](#set-constant-to-all-edges)
-    + [Set Relation](#set-relation-2)
-    + [Set Multiplier](#set-multiplier-2)
-    + [Set Priority](#set-priority-2)
-    + [All Above](#all-above-2)
-  * [Constraint to `UIViewController`](#constraint-to--uiviewcontroller-)
-    + [Ignore SafeArea or Guides](#ignore-safearea-or-guides)
-    + [All Modifiers](#all-modifiers)
-  * [Constraint to `superview`](#constraint-to--superview--1)
-    + [All Modifiers](#all-modifiers-1)
-- [Center](#center)
-  * [Constraint center between 2 elements](#constraint-center-between-2-elements)
-    + [Set Constant to One Axis](#set-constant-to-one-axis)
-    + [Set Constant to All Edges](#set-constant-to-all-edges-1)
-    + [Set Relation](#set-relation-3)
-    + [Set Multiplier](#set-multiplier-3)
-    + [Set Priority](#set-priority-3)
-    + [All Above](#all-above-3)
-  * [Constraint to `UIViewController`](#constraint-to--uiviewcontroller--1)
-    + [All Modifiers](#all-modifiers-2)
-  * [Constraint to `superview`](#constraint-to--superview--2)
-    + [All Modifiers](#all-modifiers-3)
-- [Utils](#utils)
-  * [`UILayoutPriority` Operators](#-uilayoutpriority--operators)
-
+* [Core](#core)
+  + [Constrain between equal attributes](#constrain-between-equal-attributes)
+    - [Multiple Attributes](#multiple-attributes)
+    - [Set Constant for all attributes](#set-constant-for-all-attributes)
+    - [Set Constan for a specific attribute](#set-constan-for-a-specific-attribute)
+    - [Set Relation](#set-relation)
+    - [Set Multiplier](#set-multiplier)
+    - [Set Priority](#set-priority)
+    - [All Above](#all-above)
+  + [Constrain between different attributes](#constrain-between-different-attributes)
+    - [Set Constant](#set-constant)
+    - [Set Relation](#set-relation-1)
+    - [Set Multiplier](#set-multiplier-1)
+    - [Set Priority](#set-priority-1)
+    - [All Above](#all-above-1)
+  + [Constrain to `superview`](#constrain-to--superview-)
+* [Edges](#edges)
+  + [Constrain edges between 2 elements](#constrain-edges-between-2-elements)
+    - [Set Constant to One Edge](#set-constant-to-one-edge)
+    - [Set Constant to Two or More Edges](#set-constant-to-two-or-more-edges)
+    - [Set Constant to All Edges](#set-constant-to-all-edges)
+    - [Set Relation](#set-relation-2)
+    - [Set Multiplier](#set-multiplier-2)
+    - [Set Priority](#set-priority-2)
+    - [All Above](#all-above-2)
+  + [Constrain to `UIViewController`](#constrain-to--uiviewcontroller-)
+    - [Ignore SafeArea or Guides](#ignore-safearea-or-guides)
+    - [All Modifiers](#all-modifiers)
+  + [Constrain to `superview`](#constrain-to--superview--1)
+    - [All Modifiers](#all-modifiers-1)
+* [Center](#center)
+  + [Constraint center between 2 elements](#constraint-center-between-2-elements)
+    - [Set Constant to One Axis](#set-constant-to-one-axis)
+    - [Set Constant to All Edges](#set-constant-to-all-edges-1)
+    - [Set Relation](#set-relation-3)
+    - [Set Multiplier](#set-multiplier-3)
+    - [Set Priority](#set-priority-3)
+    - [All Above](#all-above-3)
+  + [Constrain to `UIViewController`](#constrain-to--uiviewcontroller--1)
+    - [All Modifiers](#all-modifiers-2)
+  + [Constrain to `superview`](#constrain-to--superview--2)
+    - [All Modifiers](#all-modifiers-3)
+* [Size](#size)
+  + [Constrain size between 2 elements](#constrain-size-between-2-elements)
+    - [Set Constant Offset to one dimension](#set-constant-offset-to-one-dimension)
+    - [Set Constant to both dimensions (height and width)](#set-constant-to-both-dimensions--height-and-width-)
+    - [Set Relation](#set-relation-4)
+    - [Set Multiplier](#set-multiplier-4)
+    - [Set Priority](#set-priority-4)
+    - [All Above](#all-above-4)
+  + [Constrain to `superview`](#constrain-to--superview--3)
+    - [All Modifiers](#all-modifiers-4)
+  + [Constrain to Constant](#constrain-to-constant)
+    - [Different Values for Width and Height](#different-values-for-width-and-height)
+    - [Same Values for Width and Height](#same-values-for-width-and-height)
+    - [All Modifiers](#all-modifiers-5)
+* [Utils](#utils)
+  + [`UILayoutPriority` Operators](#-uilayoutpriority--operators)
 
 ## Core 
 
 With the following functions you'll be able to achieve every possible constraint. Notice that, Constrictor **takes care of handling bottom, trailing and right negative values for constant**.
 
-### Constraint between equal attributes
+### Constrain between equal attributes
 
 For example, the code bellow will constrain `aView`'s `.bottom` to `bView`'s `.bottom`
 
@@ -70,7 +83,7 @@ aView.constrict(to: bView, attribute: .bottom, .top)
 aView.constrict(to: bView, attribute: .bottom, .top, .leading, with: .all(8.0)
 ```
 
-#### Set Constant for a specific attribute
+#### Set Constan for a specific attribute
 
 ```swift
 aaView.constrict(to: bView, attribute: .bottom, .top, .leading, with: .bottom(8.0) & .top(8.0))
@@ -100,7 +113,7 @@ aaView.constrict(to: bView, attribute: .bottom, .top, .leading, prioritizeAs: .f
 aaView.constrict(as: .greaterThanOrEqual, to: bView, attribute: .bottom, .top, .leading, with: .bottom(8.0) & .top(8.0), multiplyBy: 0.5, prioritizeAs: .fittingSizeLevel)
 ```
 
-### Constraint between different attributes
+### Constrain between different attributes
 
 ```swift
 aView.constrict(.top, to: bView, attribute: .bottom)
@@ -136,7 +149,7 @@ aView.constrict(.top, to: bView, attribute: .bottom, prioritizeAs: .defaultHigh)
 aView.constrict(.top, as: .greaterThanOrEqual, to: bView, attribute: .bottom, with: 8.0, multiplyBy: 0.4, prioritizeAs: .defaultHigh)
 ```
 
-### Constraint to `superview`
+### Constrain to `superview`
 
 ```swift
 aView.constrictToParent(attributes: .top, .leading)
@@ -148,7 +161,7 @@ Setting constant, relation, multiplier and priority works the same as [Constrain
 
 The following functions will be used to apply the same edges (leading, top, trailing, bottom), if needed with modifiers like spacing, between two `Constrictable` objects.
 
-### Constraint edges between 2 elements
+### Constrain edges between 2 elements
 
 ```swift
 aView.constrictEdges(to: bView)
@@ -196,12 +209,12 @@ aView.constrictEdges(to: bView, prioritizeAs: .defaultLow)
 aView.constrictEdges(as: .greaterThanOrEqual, to: bView, with: .all(8.0), multiplyBy: 0.5, prioritizeAs: .defaultLow)
 ```
 
-### Constraint to `UIViewController`
+### Constrain to `UIViewController`
 
-Abstracts the complexity of deciding when to use `topLayoutGuide` & `bottomLayoutGuide` or `safeAreaLayoutGuide` (Pre-iOS 11.0 vs iOS 11.0 onwards).
+It's also possible to constrain to a `UIViewController` and with it you abstract the complexity of deciding when to use `topLayoutGuide` & `bottomLayoutGuide` or `safeAreaLayoutGuide` (Pre-iOS 11.0 vs iOS 11.0 onwards). You should use this everytime you want to use the `view` property from a `UIViewController`.
 
 ```swift
-aView.constrictEdgesToController(exampleController)
+aView.constrictEdges(to: exampleController)
 ```
 
 The function call and parameters are similar to [Constraint edges between 2 elements](#constraint-edges-between-2-elements)
@@ -215,10 +228,10 @@ aView.constrictEdgesToController(exampleController, withinGuides: false)
 #### All Modifiers
 
 ```swift
-aView.constrictEdgesToController(exampleController, with: .all(8.0), as: .greaterThanOrEqual, multiplyBy: 0.5, prioritizeAs: .defaultLow, withinGuides: false)
+aView.constrictEdges(to: exampleController, with: .all(8.0), as: .greaterThanOrEqual, multiplyBy: 0.5, prioritizeAs: .defaultLow, withinGuides: false)
 ```
 
-### Constraint to `superview`
+### Constrain to `superview`
 
 ```swift
 aView.constrictEdgesToParent()
@@ -278,12 +291,12 @@ aView.constrictCenter(to: bView, prioritizeAs: .defaultLow)
 aView.constrictCenter(as: .greaterThanOrEqual, to: bView, with: .all(8.0), multiplyBy: 0.5, prioritizeAs: .defaultLow)
 ```
 
-### Constraint to `UIViewController`
+### Constrain to `UIViewController`
 
-Abstracts the complexity of deciding when to use `topLayoutGuide` & `bottomLayoutGuide` or `safeAreaLayoutGuide` (Pre-iOS 11.0 vs iOS 11.0 onwards).
+It's also possible to constrain to a `UIViewController` and with it you abstract the complexity of deciding when to use `topLayoutGuide` & `bottomLayoutGuide` or `safeAreaLayoutGuide` (Pre-iOS 11.0 vs iOS 11.0 onwards). You should use this everytime you want to use the `view` property from a `UIViewController`.
 
 ```swift
-aView.constrictCenterInController(exampleController)
+aView.constrictCenter(in: exampleController)
 ```
 
 The function call and parameters are similar to [Constraint center between 2 elements](#constraint-center-between-2-elements)
@@ -294,7 +307,7 @@ The function call and parameters are similar to [Constraint center between 2 ele
 aView.constrictCenterInController(exampleController, with: .all(8.0), as: .greaterThanOrEqual, multiplyBy: 0.5, prioritizeAs: .defaultLow, withinGuides: false)
 ```
 
-### Constraint to `superview`
+### Constrain to `superview`
 
 ```swift
 aView.constrictCenterInParent()
@@ -306,6 +319,90 @@ The function call and parameters are similar to [Constraint center between 2 ele
 
 ```swift
 aView.constrictCenterInParent(as: .lessThanOrEqual, with: .all(8.0), multiplyBy: 0.7, prioritizeAs: .fittingSizeLevel)
+```
+
+## Size
+
+The following functions will be used to apply the width and height constraints.
+
+### Constrain size between 2 elements
+
+```swift
+aView.constrictSize(to: bView)
+```
+
+#### Set Constant Offset to one dimension
+
+```swift
+aView.constrictSize(to: bView, with: .width(8.0))
+```
+
+#### Set Constant to both dimensions (height and width)
+
+```swift
+aView.constrictSize(to: bView, with: .all(8.0))
+```
+
+#### Set Relation
+
+```swift
+aView.constrictSize(as: .greaterThanOrEqual, to: bView)
+```
+
+#### Set Multiplier
+
+```swift
+aView.constrictSize(to: bView, multiplyBy: 0.5)
+```
+
+#### Set Priority
+
+```swift
+aView.constrictSize(to: bView, prioritizeAs: .defaultLow)
+```
+
+#### All Above
+
+```swift
+aView.constrictSize(as: .greaterThanOrEqual, to: bView, with: .all(8.0), multiplyBy: 0.5, prioritizeAs: .defaultLow)
+```
+
+### Constrain to `superview`
+
+```swift
+aView.constrictSizeToParent()
+```
+
+The function call and parameters are similar to [Constraint size between 2 elements](#constraint-size-between-2-elements)
+
+#### All Modifiers
+
+```swift
+aView.constrictSizeToParent(as: .lessThanOrEqual, with: .all(8.0), multiplyBy: 0.7, prioritizeAs: .fittingSizeLevel)
+```
+
+### Constrain to Constant
+
+#### Different Values for Width and Height
+
+```swift
+aView.constrictSize(to: .width(50.0) & .height(100.0))
+```
+
+#### Same Values for Width and Height
+
+```swift
+aView.constrictSize(to: 100.0)
+```
+
+#### All Modifiers
+
+```swift
+aView.constrictSizeToParent(as: .lessThanOrEqual, to: .width(50.0) & .height(100.0), prioritizeAs: .fittingSizeLevel)
+```
+
+```swift
+aView.constrictSizeToParent(as: .lessThanOrEqual, to: 100.0, prioritizeAs: .fittingSizeLevel)
 ```
 
 ## Utils 

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -25,7 +25,7 @@ class ViewController: UIViewController {
         view.addSubview(redView)
 
         // Constraints -> Same dimensions of redview's superview
-        redView.constrictEdgesToController(self, withinGuides: false)
+        redView.constrictEdges(to: self, withinGuides: false)
 
         // ** Blue View **
         // Boilerplate
@@ -35,7 +35,7 @@ class ViewController: UIViewController {
         // Constraints -> 75 width, 75 height and centered in viewcontroller's view
 
         blueView.constrict(attributes: .width, .height, with: .all(75))
-            .constrictCenterInController(self)
+            .constrictCenter(in: self)
 
         // ** Green View **
         // Boilerplate

--- a/README.md
+++ b/README.md
@@ -107,13 +107,13 @@ NSLayoutConstraint.activate([
 
 ### How you can do it with Constrictor 😍
 ```swift
-redView.constrictEdgesToViewController(self, withinGuides: false)
+redView.constrictEdges(to: self, withinGuides: false)
         
-blueView.constrict(attributes: .width, .height, with: .all(75.0))
-     .constrictCenterInViewController(self)
+blueView.constrictSize(with: 75.0)
+     .constrictCenter(in: self)
 
 greenView.constrict(to: blueView, attributes: .width, .centerYGuide)
-     .constrictToSuperview(attributes: .height)
+     .constrictToParent(attributes: .height)
      .constrict(.trailing, to: blueView, attribute: .leading, with: 50.0)
 ```
 


### PR DESCRIPTION
## What was done?
* Added sugar for Size constraints (width & height)
* Fixed Documentation & README
* Updated & Removed on to apply constraints to a `ViewController`'s view

## Why?
### Size
This was mainly done to reduce the LOC needed to constraint width & height

### ViewController
Constrictor's sugar always had some function meant to be used with parent a `ViewController`'s view. The problem is, this just adds more functions & syntax when you're already able to do this with the standard functions. With this in mind, InController and toController functions were removed.

## Code Sample

### Size
```swift
aView.constrictSize(to: bView)
```
```swift
aView.constrictSize(to: bView, with: .width(8.0))
```
```swift
aView.constrictSize(to: .width(50.0) & .height(100.0))
```
```swift
aView.constrictSize(to: 100.0)
```

### ViewController

```swift
aView.constrictEdges(to: exampleController, withinGuides: false)
```
instead of: 
```swift
aView.constrictEdgesToController(exampleController, withinGuides: false)
```

## Screenshots
If there's any relevant screenshot please attach it here.
