### PR TITLE
Argument Prefix naming issues

### DIFF
--- a/Constrictor.podspec
+++ b/Constrictor.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.swift_version = "4.2"
   s.name         = "Constrictor"
-  s.version      = "4.0.0"
+  s.version      = "4.0.1"
   s.summary      = "🐍 AutoLayout's µFramework"
 
   s.description  = "(Boe) Constrictor's AutoLayout µFramework with the goal of simplying your constraints by reducing the amount of code you have to write."

--- a/Constrictor/Constrictor/Sugar/Constrictable+ConstrictorSize.swift
+++ b/Constrictor/Constrictor/Sugar/Constrictable+ConstrictorSize.swift
@@ -53,7 +53,7 @@ public extension Constrictable {
 
     @discardableResult
     func constrictSize(as relation: NSLayoutConstraint.Relation = .equal,
-                       with constant: Constant,
+                       to constant: Constant,
                        prioritizeAs priority: UILayoutPriority = .required) -> Self {
 
 
@@ -77,11 +77,11 @@ public extension Constrictable {
 
     @discardableResult
     func constrictSize(as relation: NSLayoutConstraint.Relation = .equal,
-                       with constant: CGFloat,
+                       to constant: CGFloat,
                        prioritizeAs priority: UILayoutPriority = .required) -> Self {
 
 
-        constrictSize(as: relation, with: Constant(size: constant), prioritizeAs: priority)
+        constrictSize(as: relation, to: Constant(size: constant), prioritizeAs: priority)
 
         return self
     }

--- a/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorSizeTests.swift
+++ b/Constrictor/ConstrictorTests/Tests/Sugar/UIView+ConstrictorSizeTests.swift
@@ -87,7 +87,7 @@ extension UIViewConstrictorSizeTests {
         // Setup
         viewController.view.addSubview(aView)
         viewController.view.addSubview(bView)
-        bView.constrictSize(with: .height(Constants.constant) & .width(Constants.constant * 2))
+        bView.constrictSize(to: .height(Constants.constant) & .width(Constants.constant * 2))
 
         // Tests
         let widthConstraints = bView.findConstraints(for: .width, at: .secondItem)
@@ -109,7 +109,7 @@ extension UIViewConstrictorSizeTests {
         // Setup
         viewController.view.addSubview(aView)
         viewController.view.addSubview(bView)
-        bView.constrictSize(with: Constants.constant)
+        bView.constrictSize(to: Constants.constant)
 
         // Tests
         let widthConstraints = bView.findConstraints(for: .width, at: .secondItem)

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -33,8 +33,7 @@ class ViewController: UIViewController {
         redView.addSubview(blueView)
 
         // Constraints -> 75 width, 75 height and centered in viewcontroller's view
-
-        blueView.constrict(attributes: .width, .height, with: .all(75))
+        blueView.constrictSize(to: 75.0)
             .constrictCenter(in: self)
 
         // ** Green View **

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Constrictor (3.0.1)
+  - Constrictor (4.0.1)
 
 DEPENDENCIES:
   - Constrictor (from `..`)
@@ -9,7 +9,7 @@ EXTERNAL SOURCES:
     :path: ".."
 
 SPEC CHECKSUMS:
-  Constrictor: 9cc4316728fcd05fa09b7cf19ad03ed042472a0c
+  Constrictor: 467026945defda6be01655737d8927160c97775b
 
 PODFILE CHECKSUM: 378ecc6ae0c8cd6d7e4d84896a541255c3c32287
 


### PR DESCRIPTION
## What was done?
* Fixed argument prefix for constrictSize in cases where you constrain to a value

## Why?
This was mainly done for consistency across all sugar

## Code Sample
`x.constrictSize(to: 75.0)`instead of `x.constrictSize(with: 75.0)`
