### PR TITLE
Fix layout guide issue

### DIFF
--- a/Constrictor.podspec
+++ b/Constrictor.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
   s.swift_version = "4.2"
   s.name         = "Constrictor"
-  s.version      = "4.1.0"
+  s.version      = "4.1.1"
   s.summary      = "🐍 AutoLayout's µFramework"
 
   s.description  = "(Boe) Constrictor's AutoLayout µFramework with the goal of simplying your constraints by reducing the amount of code you have to write."

--- a/Constrictor/Constrictor/Factory/LayoutItemFactory.swift
+++ b/Constrictor/Constrictor/Factory/LayoutItemFactory.swift
@@ -150,9 +150,9 @@ private extension LayoutItemFactory {
             constant = constantStruct.top
             
             if let atLeastiOS11 = atLeastiOS11, !atLeastiOS11,
-                let vc = viewController, let _ = safeLayoutGuide(for: vc) {
+                let vc = viewController, let fakeSafeArea = safeLayoutGuide(for: vc) {
                 
-                element = vc.topLayoutGuide
+                element = fakeSafeArea
                 
             } else { element = safeArea }
             
@@ -165,9 +165,9 @@ private extension LayoutItemFactory {
             constant = -constantStruct.bottom
             
             if let atLeastiOS11 = atLeastiOS11, !atLeastiOS11,
-                let vc = viewController, let _ = safeLayoutGuide(for: vc) {
+                let vc = viewController, let fakeSafeArea = safeLayoutGuide(for: vc) {
                 
-                element = vc.bottomLayoutGuide
+                element = fakeSafeArea
                 
             } else { element = safeArea }
             

--- a/Constrictor/Constrictor/Factory/LayoutItemFactory.swift
+++ b/Constrictor/Constrictor/Factory/LayoutItemFactory.swift
@@ -250,7 +250,7 @@ private extension LayoutItemFactory {
     static func safeLayoutGuide(for viewController: UIViewController) -> UILayoutGuide? {
         
         let fakeSafeArea = viewController.view.layoutGuides
-            .filter { $0.identifier == Constants.fakeSafeAreaIdentifier }
+            .filter(isFakeSafeArea)
             .first
         
         guard fakeSafeArea == nil else { return fakeSafeArea }
@@ -285,5 +285,9 @@ private extension LayoutItemFactory {
         )
         
         return layoutGuide
+    }
+    
+    static func isFakeSafeArea(_ layoutGuide: UILayoutGuide) -> Bool {
+        return layoutGuide.identifier == Constants.fakeSafeAreaIdentifier
     }
 }

--- a/Constrictor/Constrictor/Factory/LayoutItemFactory.swift
+++ b/Constrictor/Constrictor/Factory/LayoutItemFactory.swift
@@ -10,46 +10,52 @@ import Foundation
 
 // MARK: - LayoutItemFactory
 struct LayoutItemFactory {
-
+    
+    // MARK: Constants
+    private enum Constants {
+        
+        static let fakeSafeAreaIdentifier = "fakeSafeArea"
+    }
+    
     /**
      Converts a set of attributes, elements and constant into two LayoutItems
-
+     
      - parameters:
      - firstElement: Optional Constrictable's to extract NSLayoutConstraint.Attribute from.
      - secondElement: Optional Constrictable's to extract NSLayoutConstraint.Attribute from.
      - firstAttribute: ConstrictorAttributor from the first element.
      - secondAttribute: ConstrictorAttributor from the second element.
      - constant: Constant to be applied to the first element.
-
+     
      - returns:
      Tuple containing an HeadLayoutImte & TailLayoutItem (starting anchor and ending anchor).
      */
     static func makeLayoutItems(firstElement: Constrictable?, secondElement: Constrictable?,
                                 firstAttribute: ConstrictorAttribute, secondAttribute: ConstrictorAttribute,
                                 constant: Constant) -> (head: HeadLayoutItem, tail: TailLayoutItem) {
-
+        
         let firstItem = layoutItem(for: firstElement, attribute: firstAttribute, constant: constant)
         let secondItem = layoutItem(for: secondElement, attribute: secondAttribute, constant: constant)
-
+        
         return (firstItem.asHead, secondItem.asTail)
     }
-
+    
     /**
      Converts an attribute, element and constant into a LayoutItem
-
+     
      - parameters:
      - element: Optional Constrictable's to extract NSLayoutConstraint.Attribute from.
      - attribute: ConstrictorAttributor from the  element.
      - constant: Constant to be applied.
-
+     
      - returns:
      HeadLayoutItem
      */
-
+    
     static func makeLayoutItem(element: Constrictable?,
                                attribute: ConstrictorAttribute,
                                constant: Constant) -> HeadLayoutItem {
-
+        
         return layoutItem(for: element, attribute: attribute, constant: constant).asHead
     }
 }
@@ -57,14 +63,14 @@ struct LayoutItemFactory {
 
 // MARK: - Decision Maker
 private extension LayoutItemFactory {
-
-
+    
+    
     static func layoutItem(for element: Constrictable?,
                            attribute: ConstrictorAttribute,
                            constant: Constant) -> LayoutItem {
-
+        
         var item = LayoutItem()
-
+        
         if let view = element as? UIView {
             item = layoutItem(view: view, with: attribute, and: constant)
         } else if let viewController = element as? UIViewController {
@@ -72,39 +78,39 @@ private extension LayoutItemFactory {
         } else if let layoutGuide = element as? UILayoutGuide {
             item = layoutItem(layoutGuide: layoutGuide, with: attribute, and: constant)
         }
-
+        
         return item
     }
-
+    
     static func layoutItem(layoutGuide: UILayoutGuide,
                            with attribute: ConstrictorAttribute,
                            and constantStruct: Constant) -> LayoutItem {
-
+        
         return buildLayoutItem(for: attribute, with: constantStruct, safeArea: layoutGuide)
     }
-
+    
     static func layoutItem(view: UIView,
                            with attribute: ConstrictorAttribute,
                            and constantStruct: Constant) -> LayoutItem {
-
+        
         let safeArea: Any
-
+        
         if #available(iOS 11.0, *), ConstrictorAttribute.guidedAttributes.contains(attribute) {
             safeArea = view.safeAreaLayoutGuide
         } else {
             safeArea = view
         }
-
+        
         return buildLayoutItem(for: attribute, with: constantStruct, safeArea: safeArea)
     }
-
+    
     static func layoutItem(viewController: UIViewController,
                            with constrictorAttribute: ConstrictorAttribute,
                            and constantStruct: Constant) -> LayoutItem {
-
+        
         let safeArea: Any
         let atLeastiOS11: Bool
-
+        
         if #available(iOS 11.0, *), ConstrictorAttribute.guidedAttributes.contains(constrictorAttribute) {
             safeArea = viewController.view.safeAreaLayoutGuide
             atLeastiOS11 = true
@@ -112,7 +118,7 @@ private extension LayoutItemFactory {
             safeArea = viewController.view
             atLeastiOS11 = false
         }
-
+        
         return buildLayoutItem(for: constrictorAttribute,
                                with: constantStruct,
                                viewController: viewController,
@@ -123,115 +129,136 @@ private extension LayoutItemFactory {
 
 // MARK: - Builder
 private extension LayoutItemFactory {
-
+    
     static func buildLayoutItem(for constrictorAttribute: ConstrictorAttribute,
                                 with constantStruct: Constant,
                                 viewController: UIViewController? = nil,
                                 atLeastiOS11: Bool? = nil,
                                 safeArea: Any) -> LayoutItem {
-
+        
         let attribute: NSLayoutConstraint.Attribute
         let constant: CGFloat
         var element = safeArea
-
+        
         switch constrictorAttribute {
         case .top:
             attribute = .top
             constant = constantStruct.top
-
+            
         case .topGuide:
             attribute = .top
             constant = constantStruct.top
-
-            if let atLeastiOS11 = atLeastiOS11, !atLeastiOS11, let vc = viewController { element = vc.topLayoutGuide
+            
+            if let atLeastiOS11 = atLeastiOS11, !atLeastiOS11,
+                let vc = viewController, let _ = safeLayoutGuide(for: vc) {
+                
+                element = vc.topLayoutGuide
+                
             } else { element = safeArea }
-
+            
         case .bottom:
             attribute = .bottom
             constant = -constantStruct.bottom
-
+            
         case .bottomGuide:
             attribute = .bottom
             constant = -constantStruct.bottom
-
-            if let atLeastiOS11 = atLeastiOS11, !atLeastiOS11, let vc = viewController { element = vc.bottomLayoutGuide
+            
+            if let atLeastiOS11 = atLeastiOS11, !atLeastiOS11,
+                let vc = viewController, let _ = safeLayoutGuide(for: vc) {
+                
+                element = vc.bottomLayoutGuide
+                
             } else { element = safeArea }
-
+            
         case .right, .rightGuide:
             attribute = .right
             constant = -constantStruct.right
-
+            
         case .left, .leftGuide:
             attribute = .left
             constant = constantStruct.left
-
+            
         case .leading, .leadingGuide:
             attribute = .leading
             constant = constantStruct.leading
-
+            
         case .trailing, .trailingGuide:
             attribute = .trailing
             constant = -constantStruct.trailing
-
+            
         case .centerX:
             attribute = .centerX
             constant = constantStruct.x
-
+            
         case .centerXGuide:
             attribute = .centerX
             constant = constantStruct.x
-
-            if let atLeastiOS11 = atLeastiOS11, !atLeastiOS11, let vc = viewController {
-                element = safeLayoutGuide(for: vc)
+            
+            if let atLeastiOS11 = atLeastiOS11, !atLeastiOS11,
+                let vc = viewController, let fakeSafeArea = safeLayoutGuide(for: vc) {
+                
+                element = fakeSafeArea
+                
             } else { element = safeArea }
-
+            
         case .centerY:
             attribute = .centerY
             constant = constantStruct.y
-
+            
         case .centerYGuide:
             attribute = .centerY
             constant = constantStruct.y
-
-            if let atLeastiOS11 = atLeastiOS11, !atLeastiOS11, let vc = viewController {
-                element = safeLayoutGuide(for: vc)
+            
+            if let atLeastiOS11 = atLeastiOS11, !atLeastiOS11,
+                let vc = viewController, let fakeSafeArea = safeLayoutGuide(for: vc) {
+                
+                element = fakeSafeArea
+                
             } else { element = safeArea }
-
+            
         case .width:
             attribute = .width
             constant = constantStruct.width
-
+            
         case .height:
             attribute = .height
             constant = constantStruct.height
-
+            
         case .none:
             attribute = .notAnAttribute
             constant = 0.0
         }
-
+        
         return LayoutItem(element: element, attribute: attribute, constant: constant)
     }
 }
 
 // MARK: - Utils
 private extension LayoutItemFactory {
-
+    
     /**
-     Get an UILayoutGuide pinned to the viewController's safe edges. 
-
+     Get an UILayoutGuide pinned to the viewController's safe edges.
+     
      - parameters:
      - viewController: UIViewController to get an UILayoutGuide pinned its edges
-
+     
      - returns:
      Safe UILayoutGuide.
      */
-
-    static func safeLayoutGuide(for viewController: UIViewController) -> UILayoutGuide {
-
+    
+    static func safeLayoutGuide(for viewController: UIViewController) -> UILayoutGuide? {
+        
+        let fakeSafeArea = viewController.view.layoutGuides
+            .filter { $0.identifier == Constants.fakeSafeAreaIdentifier }
+            .first
+        
+        guard fakeSafeArea == nil else { return fakeSafeArea }
+        
         let layoutGuide = UILayoutGuide()
+        layoutGuide.identifier = Constants.fakeSafeAreaIdentifier
         viewController.view.addLayoutGuide(layoutGuide)
-
+        
         NSLayoutConstraint.activate(
             [
                 NSLayoutConstraint(
@@ -256,7 +283,7 @@ private extension LayoutItemFactory {
                 )
             ]
         )
-
+        
         return layoutGuide
     }
 }

--- a/Constrictor/ConstrictorTests/Tests/Enumerations/LayoutItemFactoryTests.swift
+++ b/Constrictor/ConstrictorTests/Tests/Enumerations/LayoutItemFactoryTests.swift
@@ -320,11 +320,22 @@ extension LayoutItemFactoryTests {
 
         test(viewController, for: .none, expectedAttribute: .notAnAttribute, constant: .all(Constants.constant), expectedConstant: 0.0)
     }
+    
+    func testSafeLayoutGuideFakeArea() {
+        testFakeArea(viewController)
+    }
 }
 
 // MARK: - Utils
 private extension LayoutItemFactoryTests {
 
+    func testFakeArea(_ viewController: UIViewController) {
+        let item1 = LayoutItemFactory.makeLayoutItem(element: viewController, attribute: .topGuide, constant: .top(20))
+        let item2 = LayoutItemFactory.makeLayoutItem(element: viewController, attribute: .topGuide, constant: .top(20))
+        
+        XCTAssertEqual(item1.attribute, item2.attribute)
+    }
+    
     func test(_ view: UIView,
               for attribute: ConstrictorAttribute,
               expectedAttribute: NSLayoutConstraint.Attribute,

--- a/Constrictor/ConstrictorTests/Tests/Enumerations/LayoutItemFactoryTests.swift
+++ b/Constrictor/ConstrictorTests/Tests/Enumerations/LayoutItemFactoryTests.swift
@@ -323,11 +323,15 @@ extension LayoutItemFactoryTests {
     
     func testSafeLayoutGuideFakeArea() {
 
-        let (_, tail) = LayoutItemFactory.makeLayoutItems(firstElement: UIView(), secondElement: viewController, firstAttribute: .centerXGuide, secondAttribute: .centerXGuide, constant: .all(Constants.constant))
+        let (_, tail) = LayoutItemFactory.makeLayoutItems(firstElement: UIView(), secondElement: viewController,
+                                                          firstAttribute: .centerXGuide, secondAttribute: .centerXGuide,
+                                                          constant: .all(Constants.constant))
         
         XCTAssertTrue(tail.element is UILayoutGuide)
         
-        let (_, tail2) = LayoutItemFactory.makeLayoutItems(firstElement: UIView(), secondElement: viewController, firstAttribute: .centerXGuide, secondAttribute: .centerXGuide, constant: .all(Constants.constant))
+        let (_, tail2) = LayoutItemFactory.makeLayoutItems(firstElement: UIView(), secondElement: viewController,
+                                                           firstAttribute: .topGuide, secondAttribute: .topGuide,
+                                                           constant: .all(Constants.constant))
         
         XCTAssertTrue(tail2.element is UILayoutGuide)
         XCTAssertEqual(tail.element as? UILayoutGuide, tail2.element as? UILayoutGuide)

--- a/Constrictor/ConstrictorTests/Tests/Enumerations/LayoutItemFactoryTests.swift
+++ b/Constrictor/ConstrictorTests/Tests/Enumerations/LayoutItemFactoryTests.swift
@@ -322,26 +322,20 @@ extension LayoutItemFactoryTests {
     }
     
     func testSafeLayoutGuideFakeArea() {
-        testFakeArea(viewController)
+
+        let (_, tail) = LayoutItemFactory.makeLayoutItems(firstElement: UIView(), secondElement: viewController, firstAttribute: .centerXGuide, secondAttribute: .centerXGuide, constant: .all(Constants.constant))
+        
+        XCTAssertTrue(tail.element is UILayoutGuide)
+        
+        let (_, tail2) = LayoutItemFactory.makeLayoutItems(firstElement: UIView(), secondElement: viewController, firstAttribute: .centerXGuide, secondAttribute: .centerXGuide, constant: .all(Constants.constant))
+        
+        XCTAssertTrue(tail2.element is UILayoutGuide)
+        XCTAssertEqual(tail.element as? UILayoutGuide, tail2.element as? UILayoutGuide)
     }
 }
 
 // MARK: - Utils
 private extension LayoutItemFactoryTests {
-    
-    func testFakeArea(_ viewController: UIViewController) {
-        
-        let view = UIView()
-        
-        let (_, tail) = LayoutItemFactory.makeLayoutItems(firstElement: view, secondElement: viewController, firstAttribute: .centerXGuide, secondAttribute: .centerXGuide, constant: .all(Constants.constant))
-        
-        XCTAssertTrue(tail.element is UILayoutGuide)
-        
-        let (_, tail2) = LayoutItemFactory.makeLayoutItems(firstElement: view, secondElement: viewController, firstAttribute: .centerXGuide, secondAttribute: .centerXGuide, constant: .all(Constants.constant))
-        
-        XCTAssertTrue(tail2.element is UILayoutGuide)
-        XCTAssertEqual(tail.element as? UILayoutGuide, tail2.element as? UILayoutGuide)
-    }
     
     func test(_ view: UIView,
               for attribute: ConstrictorAttribute,

--- a/Constrictor/ConstrictorTests/Tests/Enumerations/LayoutItemFactoryTests.swift
+++ b/Constrictor/ConstrictorTests/Tests/Enumerations/LayoutItemFactoryTests.swift
@@ -11,27 +11,27 @@ import XCTest
 
 // MARK: - LayoutItemFactoryTests
 class LayoutItemFactoryTests: XCTestCase {
-
+    
     private var parent: UIView!
     private var view: UIView!
     private var viewController: UIViewController!
     private var layoutGuide: UILayoutGuide!
-
+    
     // MARK:  Constants
     private enum Constants {
         static let constant: CGFloat = 50.0
     }
-
+    
     // MARK: Lifecycle
     override func setUp() {
         super.setUp()
-
+        
         parent = UIView()
-
+        
         view = UIView()
         viewController = UIViewController()
         layoutGuide = UILayoutGuide()
-
+        
         parent.addSubview(view)
         parent.addSubview(viewController.view)
     }
@@ -39,285 +39,285 @@ class LayoutItemFactoryTests: XCTestCase {
 
 // MARK: - Tests
 extension LayoutItemFactoryTests {
-
+    
     // MARK:  itemLayoutAttribute(for item: Constrictable?) -> (item: Any?, layoutAttribute: NSLayoutConstraint.Attribute)
     func testItemLayoutAttributeForUIViewNone() {
-
+        
         test(view, for: .none, expectedAttribute: .notAnAttribute, constant: .all(Constants.constant), expectedConstant: 0.0)
     }
-
+    
     func testItemLayoutAttributeForUIViewTop() {
-
+        
         test(view, for: .top, expectedAttribute: .top, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewTopGuide() {
-
+        
         test(view, for: .topGuide, expectedAttribute: .top, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewBottom() {
-
+        
         test(view, for: .bottom, expectedAttribute: .bottom, constant: .all(Constants.constant), expectedConstant: -Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewBottomGuide() {
-
+        
         test(view, for: .bottomGuide, expectedAttribute: .bottom, constant: .all(Constants.constant), expectedConstant: -Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewRight() {
-
+        
         test(view, for: .right, expectedAttribute: .right, constant: .all(Constants.constant), expectedConstant: -Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewRightGuide() {
-
+        
         test(view, for: .rightGuide, expectedAttribute: .right, constant: .all(Constants.constant), expectedConstant: -Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewLeft() {
-
+        
         test(view, for: .left, expectedAttribute: .left, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewLeftGuide() {
-
+        
         test(view, for: .leftGuide, expectedAttribute: .left, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewLeading() {
-
+        
         test(view, for: .leading, expectedAttribute: .leading, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewLeadingGuide() {
-
+        
         test(view, for: .leadingGuide, expectedAttribute: .leading, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewTrailing() {
-
+        
         test(view, for: .trailing, expectedAttribute: .trailing, constant: .all(Constants.constant), expectedConstant: -Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewTrailingGuide() {
-
+        
         test(view, for: .trailingGuide, expectedAttribute: .trailing, constant: .all(Constants.constant), expectedConstant: -Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewCenterX() {
-
+        
         test(view, for: .centerX, expectedAttribute: .centerX, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewCenterXGuide() {
-
+        
         test(view, for: .centerXGuide, expectedAttribute: .centerX, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewCenterY() {
-
+        
         test(view, for: .centerY, expectedAttribute: .centerY, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewCenterYGuide() {
-
+        
         test(view, for: .centerYGuide, expectedAttribute: .centerY, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewWidth() {
-
+        
         test(view, for: .width, expectedAttribute: .width, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewHeight() {
-
+        
         test(view, for: .height, expectedAttribute: .height, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUILayoutGuideTop() {
-
+        
         test(layoutGuide, for: .top, expectedAttribute: .top, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUILayoutGuideTopGuide() {
-
+        
         test(layoutGuide, for: .topGuide, expectedAttribute: .top, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUILayoutGuideBottom() {
-
+        
         test(layoutGuide, for: .bottom, expectedAttribute: .bottom, constant: .all(Constants.constant), expectedConstant: -Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUILayoutGuideBottomGuide() {
-
+        
         test(layoutGuide, for: .bottomGuide, expectedAttribute: .bottom, constant: .all(Constants.constant), expectedConstant: -Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUILayoutGuideRight() {
-
+        
         test(layoutGuide, for: .right, expectedAttribute: .right, constant: .all(Constants.constant), expectedConstant: -Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUILayoutGuideRightGuide() {
-
+        
         test(layoutGuide, for: .rightGuide, expectedAttribute: .right, constant: .all(Constants.constant), expectedConstant: -Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUILayoutGuideLeft() {
-
+        
         test(layoutGuide, for: .left, expectedAttribute: .left, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUILayoutGuideLeftGuide() {
-
+        
         test(layoutGuide, for: .leftGuide, expectedAttribute: .left, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUILayoutGuideLeading() {
-
+        
         test(layoutGuide, for: .leading, expectedAttribute: .leading, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUILayoutGuideLeadingGuide() {
-
+        
         test(layoutGuide, for: .leadingGuide, expectedAttribute: .leading, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUILayoutGuideTrailing() {
-
+        
         test(layoutGuide, for: .trailing, expectedAttribute: .trailing, constant: .all(Constants.constant), expectedConstant: -Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUILayoutGuideTrailingGuide() {
-
+        
         test(layoutGuide, for: .trailingGuide, expectedAttribute: .trailing, constant: .all(Constants.constant), expectedConstant: -Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUILayoutGuideCenterX() {
-
+        
         test(layoutGuide, for: .centerX, expectedAttribute: .centerX, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUILayoutGuideCenterXGuide() {
-
+        
         test(layoutGuide, for: .centerXGuide, expectedAttribute: .centerX, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUILayoutGuideCenterY() {
-
+        
         test(layoutGuide, for: .centerY, expectedAttribute: .centerY, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUILayoutGuideCenterYGuide() {
-
+        
         test(layoutGuide, for: .centerYGuide, expectedAttribute: .centerY, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUILayoutGuideWidth() {
-
+        
         test(layoutGuide, for: .width, expectedAttribute: .width, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUILayoutGuideHeight() {
-
+        
         test(layoutGuide, for: .height, expectedAttribute: .height, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewControllerTop() {
-
+        
         test(viewController, for: .top, expectedAttribute: .top, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewControllerTopGuide() {
-
+        
         test(viewController, for: .topGuide, expectedAttribute: .top, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewControllerBottom() {
-
+        
         test(viewController, for: .bottom, expectedAttribute: .bottom, constant: .all(Constants.constant), expectedConstant: -Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewControllerBottomGuide() {
-
+        
         test(viewController, for: .bottomGuide, expectedAttribute: .bottom, constant: .all(Constants.constant), expectedConstant: -Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewControllerRight() {
-
+        
         test(viewController, for: .right, expectedAttribute: .right, constant: .all(Constants.constant), expectedConstant: -Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewControllerRightGuide() {
-
+        
         test(viewController, for: .rightGuide, expectedAttribute: .right, constant: .all(Constants.constant), expectedConstant: -Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewControllerLeft() {
-
+        
         test(viewController, for: .left, expectedAttribute: .left, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewControllerLeftGuide() {
-
+        
         test(viewController, for: .leftGuide, expectedAttribute: .left, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewControllerLeading() {
-
+        
         test(viewController, for: .leading, expectedAttribute: .leading, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewControllerLeadingGuide() {
-
+        
         test(viewController, for: .leadingGuide, expectedAttribute: .leading, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewControllerTrailing() {
-
+        
         test(viewController, for: .trailing, expectedAttribute: .trailing, constant: .all(Constants.constant), expectedConstant: -Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewControllerTrailingGuide() {
-
+        
         test(viewController, for: .trailingGuide, expectedAttribute: .trailing, constant: .all(Constants.constant), expectedConstant: -Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewControllerCenterX() {
-
+        
         test(viewController, for: .centerX, expectedAttribute: .centerX, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewControllerCenterXGuide() {
-
+        
         test(viewController, for: .centerXGuide, expectedAttribute: .centerX, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewControllerCenterY() {
-
+        
         test(viewController, for: .centerY, expectedAttribute: .centerY, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewControllerCenterYGuide() {
-
+        
         test(viewController, for: .centerYGuide, expectedAttribute: .centerY, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewControllerWidth() {
-
+        
         test(viewController, for: .width, expectedAttribute: .width, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewControllerHeight() {
-
+        
         test(viewController, for: .height, expectedAttribute: .height, constant: .all(Constants.constant), expectedConstant: Constants.constant)
     }
-
+    
     func testItemLayoutAttributeForUIViewControllerNone() {
-
+        
         test(viewController, for: .none, expectedAttribute: .notAnAttribute, constant: .all(Constants.constant), expectedConstant: 0.0)
     }
     
@@ -328,7 +328,7 @@ extension LayoutItemFactoryTests {
 
 // MARK: - Utils
 private extension LayoutItemFactoryTests {
-
+    
     func testFakeArea(_ viewController: UIViewController) {
         
         let view = UIView()
@@ -348,81 +348,63 @@ private extension LayoutItemFactoryTests {
               expectedAttribute: NSLayoutConstraint.Attribute,
               constant: Constant = .zero,
               expectedConstant: CGFloat = 0.0) {
-
+        
         let items = LayoutItemFactory.makeLayoutItems(firstElement: parent,
                                                       secondElement: view,
                                                       firstAttribute: attribute,
                                                       secondAttribute: attribute,
                                                       constant: constant)
-
+        
         if #available(iOS 11.0, *), ConstrictorAttribute.guidedAttributes.contains(attribute) {
-
+            
             let expectedItem = view.safeAreaLayoutGuide
             XCTAssertEqual(items.tail.element as? UILayoutGuide, expectedItem)
-
+            
         } else {
-
+            
             let expectedItem = view
             XCTAssertEqual(items.tail.element as? UIView, expectedItem)
         }
-
+        
         XCTAssertEqual(items.head.attribute, expectedAttribute)
         XCTAssertEqual(items.tail.attribute, expectedAttribute)
         XCTAssertEqual(items.head.constant, expectedConstant)
     }
-
+    
     func test(_ layoutGuide: UILayoutGuide,
               for attribute: ConstrictorAttribute,
               expectedAttribute: NSLayoutConstraint.Attribute,
               constant: Constant = .zero,
               expectedConstant: CGFloat = 0.0) {
-
+        
         let item = LayoutItemFactory.makeLayoutItem(element: layoutGuide,
                                                     attribute: attribute,
                                                     constant: constant)
-
+        
         XCTAssertEqual(item.attribute, expectedAttribute)
         XCTAssertEqual(item.constant, expectedConstant)
     }
-
+    
     func test(_ viewController: UIViewController,
               for attribute: ConstrictorAttribute,
               expectedAttribute: NSLayoutConstraint.Attribute,
               constant: Constant = .zero,
               expectedConstant: CGFloat = 0.0) {
-
+        
         let items = LayoutItemFactory.makeLayoutItems(firstElement: parent,
                                                       secondElement: viewController,
                                                       firstAttribute: attribute,
                                                       secondAttribute: attribute,
                                                       constant: constant)
-
+        
         if #available(iOS 11.0, *), ConstrictorAttribute.guidedAttributes.contains(attribute) {
-
             let expectedItem = viewController.view.safeAreaLayoutGuide
             XCTAssertEqual(items.tail.element as? UILayoutGuide, expectedItem)
-
-        } else if attribute == .centerXGuide { XCTAssertNotNil(items.tail.element as? UILayoutGuide)
-        } else if attribute == .centerYGuide { XCTAssertNotNil(items.tail.element as? UILayoutGuide)
-        } else if attribute == .topGuide {
-
-            let expectedItem = viewController.topLayoutGuide
-            guard let resultItem = items.tail.element as? UILayoutSupport else { return XCTFail() }
-
-            XCTAssert(resultItem.isEqual(expectedItem))
-
-            return
-
-        } else if attribute == .bottomGuide {
-
-            let expectedItem = viewController.bottomLayoutGuide
-            guard let resultItem = items.tail.element as? UILayoutSupport else { return XCTFail() }
-
-            XCTAssert(resultItem.isEqual(expectedItem))
-
-            return
+        } else if [ConstrictorAttribute.centerXGuide, ConstrictorAttribute.centerYGuide,
+                   ConstrictorAttribute.topGuide, ConstrictorAttribute.bottomGuide].contains(attribute) {
+            XCTAssertNotNil(items.tail.element as? UILayoutGuide)
         }
-
+        
         XCTAssertEqual(items.head.attribute, expectedAttribute)
         XCTAssertEqual(items.tail.attribute, expectedAttribute)
         XCTAssertEqual(items.head.constant, expectedConstant)

--- a/Constrictor/ConstrictorTests/Tests/Enumerations/LayoutItemFactoryTests.swift
+++ b/Constrictor/ConstrictorTests/Tests/Enumerations/LayoutItemFactoryTests.swift
@@ -333,11 +333,11 @@ private extension LayoutItemFactoryTests {
         
         let view = UIView()
         
-        let (_, tail) = LayoutItemFactory.makeLayoutItems(firstElement: view, secondElement: viewController, firstAttribute: .topGuide, secondAttribute: .topGuide, constant: .all(Constants.constant))
+        let (_, tail) = LayoutItemFactory.makeLayoutItems(firstElement: view, secondElement: viewController, firstAttribute: .centerXGuide, secondAttribute: .centerXGuide, constant: .all(Constants.constant))
         
         XCTAssertTrue(tail.element is UILayoutGuide)
         
-        let (_, tail2) = LayoutItemFactory.makeLayoutItems(firstElement: view, secondElement: viewController, firstAttribute: .topGuide, secondAttribute: .topGuide, constant: .all(Constants.constant))
+        let (_, tail2) = LayoutItemFactory.makeLayoutItems(firstElement: view, secondElement: viewController, firstAttribute: .centerXGuide, secondAttribute: .centerXGuide, constant: .all(Constants.constant))
         
         XCTAssertTrue(tail2.element is UILayoutGuide)
         XCTAssertEqual(tail.element as? UILayoutGuide, tail2.element as? UILayoutGuide)

--- a/Constrictor/ConstrictorTests/Tests/Enumerations/LayoutItemFactoryTests.swift
+++ b/Constrictor/ConstrictorTests/Tests/Enumerations/LayoutItemFactoryTests.swift
@@ -320,11 +320,29 @@ extension LayoutItemFactoryTests {
 
         test(viewController, for: .none, expectedAttribute: .notAnAttribute, constant: .all(Constants.constant), expectedConstant: 0.0)
     }
+    
+    func testSafeLayoutGuideFakeArea() {
+        testFakeArea(viewController)
+    }
 }
 
 // MARK: - Utils
 private extension LayoutItemFactoryTests {
 
+    func testFakeArea(_ viewController: UIViewController) {
+        
+        let view = UIView()
+        
+        let (_, tail) = LayoutItemFactory.makeLayoutItems(firstElement: view, secondElement: viewController, firstAttribute: .topGuide, secondAttribute: .topGuide, constant: .all(Constants.constant))
+        
+        XCTAssertTrue(tail.element is UILayoutGuide)
+        
+        let (_, tail2) = LayoutItemFactory.makeLayoutItems(firstElement: view, secondElement: viewController, firstAttribute: .topGuide, secondAttribute: .topGuide, constant: .all(Constants.constant))
+        
+        XCTAssertTrue(tail2.element is UILayoutGuide)
+        XCTAssertEqual(tail.element as? UILayoutGuide, tail2.element as? UILayoutGuide)
+    }
+    
     func test(_ view: UIView,
               for attribute: ConstrictorAttribute,
               expectedAttribute: NSLayoutConstraint.Attribute,


### PR DESCRIPTION
## What was done?
* Fixed #16

## Why?
As mentioned in the original issue, Constrictor was creating a new UILayoutGuide as a fake safe area. This PR addresses that in order to boost overall performance.